### PR TITLE
Add basic support for redacting Attribute Lists

### DIFF
--- a/src/cdoFlavoredParser.js
+++ b/src/cdoFlavoredParser.js
@@ -10,6 +10,7 @@ const restorationRegistration = require('./plugins/process/restorationRegistrati
 const indent = require('./plugins/compiler/indent');
 const rawtext = require('./plugins/compiler/rawtext');
 
+const attrlist = require('./plugins/parser/attrlist');
 const divclass = require('./plugins/parser/divclass');
 const redactedLink = require('./plugins/parser/redactedLink');
 const resourcelink = require('./plugins/parser/resourcelink');
@@ -25,6 +26,7 @@ module.exports = class CdoFlavoredParser {
   static getParserPlugins = function() {
     return [
       restorationRegistration,
+      attrlist,
       divclass,
       redactedLink,
       resourcelink,

--- a/src/plugins/parser/attrlist.js
+++ b/src/plugins/parser/attrlist.js
@@ -1,0 +1,76 @@
+let redact;
+
+const ATTRLIST_RE = /{([^}]*)}/;
+
+module.exports = function attrlist() {
+  if (this.Parser) {
+    const Parser = this.Parser;
+    const tokenizers = Parser.prototype.inlineTokenizers;
+    const methods = Parser.prototype.inlineMethods;
+    const restorationMethods = Parser.prototype.restorationMethods;
+
+    restorationMethods.attrlist = function (add, node, content) {
+      restorationMethods[node.elem.redactionType](add, node.elem, content)
+      return add({
+        type: 'rawtext',
+        value: `{${node.attrlistContent}}`
+      });
+    }
+
+    redact = Parser.prototype.options.redact;
+
+    tokenizers.attrlist = tokenizeAttrlist;
+
+    /* Run it just before `link`. */
+    methods.splice(methods.indexOf('link'), 0, 'attrlist');
+  }
+}
+
+tokenizeAttrlist.notInLink = true;
+tokenizeAttrlist.locator = locateAttrlist;
+
+function tokenizeAttrlist(eat, value, silent) {
+  const match = ATTRLIST_RE.exec(value);
+
+  if (!match) {
+    return;
+  }
+
+  // Attrlists are (so far) ONLY supported in redaction mode. Adding render
+  // support at some point would be nice, though.
+  if (!redact) {
+    return;
+  }
+
+  if (silent) {
+    return true;
+  }
+
+  const attrlist = match[0];
+  const attrlistContent = match[1];
+  const preceeding = value.slice(0, match.index);
+  const otherContent = this.tokenizeInline(preceeding, eat.now());
+  const elem = otherContent[otherContent.length - 1];
+
+  if (elem && elem.type == "redaction") {
+    const add = eat(preceeding + attrlist);
+    otherContent.slice(0, -1).forEach(e => add(e));
+
+    if (redact) {
+      return add({
+        type: 'redaction',
+        redactionType: 'attrlist',
+        attrlistContent,
+        elem,
+        children: elem.children
+      });
+    }
+  }
+}
+
+function locateAttrlist(value, fromIndex) {
+  const match = ATTRLIST_RE.exec(value);
+  if (match && match.index >= fromIndex) {
+    return match.index;
+  }
+}

--- a/test/unit/plugins/parser/attrlist.test.js
+++ b/test/unit/plugins/parser/attrlist.test.js
@@ -1,0 +1,53 @@
+const expect = require('expect');
+const parser = require('../../../../src/cdoFlavoredParser');
+
+describe('attrlist', () => {
+  describe('render', () => {
+    it('does not render basic attrlists', () => {
+      const input = "A bunch of text followed by [a link](http://example.com){ .center } with more after it";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<p>A bunch of text followed by <a href=\"http://example.com\">a link</a>{ .center } with more after it</p>\n");
+    });
+
+    it('does not render basic image attrlists', () => {
+      const input = "A bunch of text followed by ![an image](http://example.com){ .center } with more after it";
+      const output = parser.sourceToHtml(input);
+      expect(output).toEqual("<p>A bunch of text followed by <img src=\"http://example.com\" alt=\"an image\">{ .center } with more after it</p>\n");
+    });
+  });
+
+  describe('redact', () => {
+    it('does not redact brackets in code', () => {
+      const input = "A bunch of text with some random `[link](asdf)` with more after it";
+      const output = parser.sourceToRedacted(input);
+      expect(output).toEqual(input + "\n");
+    });
+
+    it('does not redact something that is just using a bracket in text', () => {
+      const input = "A bunch of text with some random { brackets } with more after it";
+      const output = parser.sourceToRedacted(input);
+      expect(output).toEqual(input + "\n");
+    });
+
+    it('redacts attrlists', () => {
+      const input = "A bunch of text followed by [a link](http://example.com){ .center } with more after it";
+      const output = parser.sourceToRedacted(input);
+      expect(output).toEqual("A bunch of text followed by [a link][0] with more after it\n");
+    });
+
+    it('redacts image attrlists', () => {
+      const input = "A bunch of text followed by ![an image](http://example.com){ .center } with more after it";
+      const output = parser.sourceToRedacted(input);
+      expect(output).toEqual("A bunch of text followed by [an image][0] with more after it\n");
+    });
+  });
+
+  describe('restore', () => {
+    it('can restore attrlists back to markdown', () => {
+      const source = "[a link](http://example.com){ .center }";
+      const redacted = "[une linke][0]";
+      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      expect(output).toEqual("[une linke](http://example.com){ .center }\n");
+    });
+  });
+});


### PR DESCRIPTION
Inspired by https://python-markdown.github.io/extensions/attr_list/

I'm not sure if we actually want to support attrlists long-term,
although given that we do not intend to support raw HTML in markdown
they might be useful, but CurriculumBuilder uses attrlists so we need to
at least be able to redact them for now.