### PR TITLE
Add version scripts and a "files" entry

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+# Build files
+!/dist
+

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-# Build files
-!/dist
-

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "render": "dist/bin/render.js",
     "restore": "dist/bin/restore.js"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "webpack -p",
     "build:dev": "webpack --progress --colors --mode=development",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/redactable-markdown",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "bin": {
     "redact": "dist/bin/redact.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "test:unit": "jest test/unit",
     "test:unit:watch": "npm run test:unit -- --watch",
     "test:integration": "jest test/integration",
-    "test:integration:watch": "npm run test:integration -- --watch"
+    "test:integration:watch": "npm run test:integration -- --watch",
+    "preversion": "npm run test",
+    "version": "npm run build",
+    "postversion": "git push && git push --tags && npm publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
files entry is so npm will only distribute `/dist`

version scripts adapted from code-dot-org/blockly