### PR TITLE
Update detection of "next block" in tip

### DIFF
--- a/src/plugins/parser/tip.js
+++ b/src/plugins/parser/tip.js
@@ -48,18 +48,21 @@ function tokenizeTip(eat, value, silent) {
     return true;
   }
 
-  // find the indented block that represents the content of the tip. Blocks can
-  // be indented by either four spaces or a tab character, and can also contain
-  // blank lines separating multiple indented blocks
+  // find the indented block that represents the content of the tip. Blocks are
+  // considered to be indented if they start with at least four spaces, where a
+  // tab is considered to be equivalent to four spaces.
+  //
+  // This is distinct from considering a block to be indented if it just starts
+  // with either four spaces or a tab in that it accounts for blocks that are
+  // indented with a combination of tabs and spaces.
   let index = match[0].length;
   while (index < value.length) {
     index++;
     if (value.charAt(index) === "\n") {
       if (value.charAt(index + 1) !== "\n") {
-        if (!(
-          value.charAt(index + 1) === "\t" ||
-          value.slice(index + 1, index + 5) === "    "
-        )) {
+        let nextLine = value.slice(index + 1, index + 5);
+        nextLine = nextLine.replace("\t", "    ");
+        if (!nextLine.startsWith("    ")) {
           break;
         }
       }

--- a/test/unit/plugins/parser/tip.test.js
+++ b/test/unit/plugins/parser/tip.test.js
@@ -24,6 +24,28 @@ describe('tip', () => {
       expect(output).toEqual(expected);
     });
 
+    it('renders a basic tip even with weird indentation', () => {
+      const input = "!!!tip \"this is an optional title, and it should be translatable\" <tip-0>\n\tThis is the content of the tip, and it should be translatable, as should all the following blocks:\n \tone\n\t\t\t\ttwo\n \t three\n              four\n\nThis is the next paragraph";
+      const output = parser.sourceToHtml(input);
+      /**
+       * <div class="admonition tip">
+       *   <p class="admonition-title" id="tip_tip-0">
+       *     <i class="fa fa-lightbulb-o"></i>
+       *     this is an optional title, and it should be translatable
+       *   </p>
+       *   <div>
+       *     <p>
+       *       This is the content of the tip, and it should be translatable, as
+       *       should all the following blocks: one two three four
+       *     </p>
+       *   </div>
+       * </div>
+       * <p>This is the next paragraph</p>
+       */
+      const expected = "<div class=\"admonition tip\"><p class=\"admonition-title\" id=\"tip_tip-0\"><i class=\"fa fa-lightbulb-o\"></i>this is an optional title, and it should be translatable</p><div><p>This is the content of the tip, and it should be translatable, as should all the following blocks:\none\ntwo\nthree\nfour</p></div></div>\n<p>This is the next paragraph</p>\n"
+      expect(output).toEqual(expected);
+    });
+
     it('renders a basic tip without an id', () => {
       const input = "!!!tip \"this is an optional title, and it should be translatable\"\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
       const output = parser.sourceToHtml(input);


### PR DESCRIPTION
To closer match how things work [in tips.py in
curriculumbuilder.](https://github.com/mrjoshida/curriculumbuilder/blob/master/curriculumBuilder/tips.py#L49)

Specifically, curriculumbuilder checks to see that a line starts with
four spaces. However, by the time this checker gets to the content all
tabs have already been replaced with four spaces, so curriculumbuilder
was accepting a different set of valid results than we were.

With this change, we should be aligned.