### PR TITLE
rename CdoFlavoredParser to RedactableMarkdownParser

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -1,7 +1,7 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 
-const CdoFlavoredParser = require('../src/cdoFlavoredParser');
+const parser = require('../src/redactableMarkdownParser');
 
 //const initialMarkdown = require('./cdo-markdown.md');
 const initialMarkdown = "This is some text with [a link](http://first.com) and ![an image](http://second.com/img.jpg).\n\nAnd also a second paragraph with [another link](http://third.com)";
@@ -11,7 +11,7 @@ class Demo extends React.Component {
     super();
     this.state = {
       sourceMarkdown: initialMarkdown,
-      redactedMarkdown: CdoFlavoredParser.sourceToRedacted(initialMarkdown),
+      redactedMarkdown: parser.sourceToRedacted(initialMarkdown),
     };
   }
 
@@ -29,7 +29,7 @@ class Demo extends React.Component {
 
   redact = () => {
     this.setState({
-      redactedMarkdown: CdoFlavoredParser.sourceToRedacted(
+      redactedMarkdown: parser.sourceToRedacted(
         this.state.sourceMarkdown,
       ),
     });
@@ -74,13 +74,13 @@ class Demo extends React.Component {
         <div
           style={this.styles.renderContainer}
           dangerouslySetInnerHTML={{
-            __html: CdoFlavoredParser.sourceToHtml(this.state.sourceMarkdown)
+            __html: parser.sourceToHtml(this.state.sourceMarkdown)
           }}
         />
         <div
           style={this.styles.renderContainer}
           dangerouslySetInnerHTML={{
-            __html: CdoFlavoredParser.sourceAndRedactedToHtml(
+            __html: parser.sourceAndRedactedToHtml(
                 this.state.sourceMarkdown,
                 this.state.redactedMarkdown,
               )

--- a/src/bin/redact.js
+++ b/src/bin/redact.js
@@ -1,7 +1,7 @@
 const parseArgs = require('minimist');
 
 const ioUtils = require('../utils/io');
-const parser = require('../cdoFlavoredParser');
+const parser = require('../redactableMarkdownParser');
 const recursivelyProcessAll = require('../utils/misc').recursivelyProcessAll;
 
 const argv = parseArgs(process.argv.slice(2));

--- a/src/bin/render.js
+++ b/src/bin/render.js
@@ -1,7 +1,7 @@
 const parseArgs = require('minimist');
 
 const ioUtils = require('../utils/io');
-const parser = require('../cdoFlavoredParser');
+const parser = require('../redactableMarkdownParser');
 const recursivelyProcessAll = require('../utils/misc').recursivelyProcessAll;
 
 const argv = parseArgs(process.argv.slice(2));

--- a/src/bin/restore.js
+++ b/src/bin/restore.js
@@ -1,7 +1,7 @@
 const parseArgs = require('minimist');
 
 const ioUtils = require('../utils/io');
-const parser = require('../cdoFlavoredParser');
+const parser = require('../redactableMarkdownParser');
 const recursivelyProcessAll = require('../utils/misc').recursivelyProcessAll;
 
 const argv = parseArgs(process.argv.slice(2));

--- a/src/redactableMarkdownParser.js
+++ b/src/redactableMarkdownParser.js
@@ -17,7 +17,7 @@ const tip = require('./plugins/parser/tip');
 const tiplink = require('./plugins/parser/tiplink');
 const vocablink = require('./plugins/parser/vocablink');
 
-module.exports = class CdoFlavoredParser {
+module.exports = class RedactableMarkdownParser {
   static getPlugins = function() {
     return this.getParserPlugins().concat(this.getCompilerPlugins());
   }

--- a/test/integration/curriculumbuilder.test.js
+++ b/test/integration/curriculumbuilder.test.js
@@ -1,5 +1,5 @@
 const expect = require('expect');
-const parser = require('../../src/cdoFlavoredParser');
+const parser = require('../../src/redactableMarkdownParser');
 const mapMdast = require('../utils').mapMdast;
 
 const lessonData = require('./data/curriculumbuilder/lesson.json');

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -1,5 +1,5 @@
 const expect = require('expect');
-const parser = require('../../src/cdoFlavoredParser');
+const parser = require('../../src/redactableMarkdownParser');
 
 describe('Standard Markdown', () => {
   describe('render', () => {

--- a/test/unit/plugins/parser/divclass.test.js
+++ b/test/unit/plugins/parser/divclass.test.js
@@ -1,5 +1,5 @@
 const expect = require('expect');
-const parser = require('../../../../src/cdoFlavoredParser');
+const parser = require('../../../../src/redactableMarkdownParser');
 
 describe('divclass', () => {
   describe('render', () => {

--- a/test/unit/plugins/parser/resourcelink.test.js
+++ b/test/unit/plugins/parser/resourcelink.test.js
@@ -1,5 +1,5 @@
 const expect = require('expect');
-const parser = require('../../../../src/cdoFlavoredParser');
+const parser = require('../../../../src/redactableMarkdownParser');
 
 describe('resourcelink', () => {
   describe('render', () => {

--- a/test/unit/plugins/parser/tip.test.js
+++ b/test/unit/plugins/parser/tip.test.js
@@ -1,5 +1,5 @@
 const expect = require('expect');
-const parser = require('../../../../src/cdoFlavoredParser');
+const parser = require('../../../../src/redactableMarkdownParser');
 
 describe('tip', () => {
   describe('render', () => {

--- a/test/unit/plugins/parser/tiplink.test.js
+++ b/test/unit/plugins/parser/tiplink.test.js
@@ -1,5 +1,5 @@
 const expect = require('expect');
-const parser = require('../../../../src/cdoFlavoredParser');
+const parser = require('../../../../src/redactableMarkdownParser');
 
 describe('tiplink', () => {
   const basicTipMarkdown = "tip!!!";

--- a/test/unit/plugins/parser/vocablink.test.js
+++ b/test/unit/plugins/parser/vocablink.test.js
@@ -1,5 +1,5 @@
 const expect = require('expect');
-const parser = require('../../../../src/cdoFlavoredParser');
+const parser = require('../../../../src/redactableMarkdownParser');
 const mapMdast = require('../../../utils').mapMdast;
 
 describe('vocablink', () => {


### PR DESCRIPTION
since this project is headed in the direction of being a generalizable tool, rather than a specific implementation of CDO-flavored markdown