### PR TITLE
 Allow for processing intersections of data 

### DIFF
--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -10,13 +10,14 @@ function recursivelyProcessAll (handler, inputs, isValue) {
   if (!Array.isArray(inputs)) {
     inputs = [inputs]
   }
-  const inputType = typeof inputs[0];
-  if (inputs.length && inputs.some(input => typeof input !== inputType)) {
-    throw Error('all data to process must have the same structure');
-  }
 
   if (inputs.some(input => !input)) {
     return;
+  }
+
+  const inputType = typeof inputs[0];
+  if (inputs.length && inputs.some(input => typeof input !== inputType)) {
+    throw Error('all data to process must have the same structure');
   }
 
   if (inputType === "string") {

--- a/test/integration/data/intersection/restored.json
+++ b/test/integration/data/intersection/restored.json
@@ -1,0 +1,11 @@
+{
+  "intersection of object keys": {
+    "one": "one",
+    "two": "two"
+  },
+  "intersection of array elements": [
+    "first",
+    "third",
+    null
+  ]
+}

--- a/test/integration/data/intersection/source.json
+++ b/test/integration/data/intersection/source.json
@@ -1,0 +1,13 @@
+{
+  "intersection of object keys": {
+    "one": "one",
+    "a": "alpha",
+    "two": "two",
+    "b": "bravo"
+  },
+  "intersection of array elements": [
+    "first",
+    "second",
+    "third"
+  ]
+}

--- a/test/integration/data/intersection/translated.json
+++ b/test/integration/data/intersection/translated.json
@@ -1,0 +1,10 @@
+{
+  "intersection of object keys": {
+    "one": "one",
+    "two": "two"
+  },
+  "intersection of array elements": [
+    "first",
+    "third"
+  ]
+}


### PR DESCRIPTION
Allow for processing intersections of data

When recursively iterating over pairs of input (which we do in the
restoration process), we check against two things: that all given inputs
are defined, and that they are of the same type.

Unfortunately, we're actually redundantly checking the latter before we
check the former, which means that we can't (as intended) deal with a
situation where the redacted data is a subset of the source data - which
is precisely the situation we are in when not all data has been
translated.

The simple fix is to swap the order of the checks, so intersections work
as intended.