### PR TITLE
Add more nuanced support for parsing emphases in pedantic mode

### DIFF
--- a/src/plugins/compiler/betterPedanticEmphasis.js
+++ b/src/plugins/compiler/betterPedanticEmphasis.js
@@ -1,0 +1,28 @@
+/**
+ * Duplicate the changes in https://github.com/remarkjs/remark/pull/344 until a
+ * version of remark-stringify is released that includes those changes.
+ */
+module.exports = function betterPedanticEmphasis() {
+  if (this.Compiler) {
+    const Compiler = this.Compiler;
+    const visitors = Compiler.prototype.visitors;
+
+    visitors.emphasis = function (node) {
+        let marker = this.options.emphasis;
+        const content = this.all(node).join('');
+
+        /* When in pedantic mode, prevent using underscore as the marker when
+        * there are underscores in the content.
+        */
+        if (
+          this.options.pedantic &&
+          marker === '_' &&
+          content.indexOf(marker) !== -1
+        ) {
+          marker = '*';
+        }
+
+      return marker + content + marker;
+    }
+  }
+}

--- a/src/redactableMarkdownParser.js
+++ b/src/redactableMarkdownParser.js
@@ -8,6 +8,7 @@ const renderRedactions = require('./plugins/process/renderRedactions');
 const restoreRedactions = require('./plugins/process/restoreRedactions');
 const restorationRegistration = require('./plugins/process/restorationRegistration');
 
+const betterPedanticEmphasis = require('./plugins/compiler/betterPedanticEmphasis');
 const div = require('./plugins/compiler/div');
 const indent = require('./plugins/compiler/indent');
 const rawtext = require('./plugins/compiler/rawtext');
@@ -114,6 +115,7 @@ module.exports = class RedactableMarkdownParser {
 
   static getCompilerPlugins() {
     return [
+      betterPedanticEmphasis,
       div,
       indent,
       rawtext,

--- a/test/unit/plugins/compiler/betterPedanticEmphasis.test.js
+++ b/test/unit/plugins/compiler/betterPedanticEmphasis.test.js
@@ -1,0 +1,32 @@
+/**
+ * @fileoverview duplicate the tests in https://github.com/remarkjs/remark/pull/344
+ */
+
+const expect = require('expect');
+const parser = require('../../../../src/redactableMarkdownParser').create();
+
+describe('pedantic emphasis', () => {
+  it('should handle underscores in emphasis in pedantic mode', () => {
+    const example = '*alpha_bravo*\n';
+    expect(parser.sourceToMarkdown(example)).toEqual('*alpha\\_bravo*\n');
+  });
+
+  describe('emphasis in pedantic mode should support a constiety of contained inline content', () => {
+    /* Data-driven tests in the format: [name, input, expected] */
+    const tests = [
+      ['words with asterisks', '*inner content*', '_inner content_\n'],
+      ['words with underscores', '_inner content_', '_inner content_\n'],
+      ['links', '*[](http://some_url.com)*', '*[](http://some_url.com)*\n'],
+      ['underscores inside asterisks', '*inner content _with_ emphasis*', '*inner content _with_ emphasis*\n'],
+      ['asterisks inside underscores', '_inner content *with* emphasis_', '*inner content _with_ emphasis*\n'],
+      ['images', '*![](http://some_url.com/img.jpg)*', '*![](http://some_url.com/img.jpg)*\n'],
+      ['inline code with asterisks', '*content `with` code*', '_content `with` code_\n'],
+      ['inline code with underscores', '_content `with` code_', '_content `with` code_\n']
+    ];
+    tests.forEach(function (test) {
+      it(test[0], () => {
+        expect(parser.sourceToMarkdown(test[1])).toEqual(test[2]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Work is duplicated in https://github.com/remarkjs/remark/pull/344, but
I'm recreating it as a plugin here until a new version of
remark-stringify is cut.