### PR TITLE
Add script to remove unredacted strings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "remark-html": "^9.0.0",
     "remark-parse": "^6.0.0",
     "remark-stringify": "^6.0.0",
-    "unified": "^7.0.0"
+    "unified": "^7.0.0",
+    "unist-util-find": "^1.0.1"
   },
   "jest": {
     "testEnvironment": "node"

--- a/src/bin/sanitize.js
+++ b/src/bin/sanitize.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+const parseArgs = require('minimist');
+
+const ioUtils = require('../utils/io');
+const parser = require('../redactableMarkdownParser').create();
+const recursivelyProcessAll = require('../utils/misc').recursivelyProcessAll;
+const requireByPath = require('../utils/misc').requireByPath;
+
+const argv = parseArgs(process.argv.slice(2));
+
+const helpFlag = (argv.h || argv.help);
+if (helpFlag) {
+  process.stdout.write("usage: sanitize [INFILE] [options]\n");
+  process.stdout.write("\n");
+  process.stdout.write("Reads content from file specified in -r.\n");
+  process.stdout.write("Content can be plain text or JSON.\n");
+  process.stdout.write("Content will be cleared if not redacted.\n");
+  process.stdout.write("\n");
+  process.stdout.write("options:\n");
+  process.stdout.write("\t-h, --help: print this help message\n");
+  process.stdout.write("\t-o OUTFILE: output to OUTFILE rather than stdout\n");
+  process.stdout.write("\t-p, --parserPlugins PLUGINS: comma-separated list of parser plugins to include in addition to the defaults\n");
+  process.stdout.write("\t-c, --compilerPlugins PLUGINS: comma-separated list of compiler plugins to include in addition to the defaults\n");
+  process.exit()
+}
+
+const parserPlugins = (argv.p || argv.parserPlugins)
+if (parserPlugins) {
+  parser.parser.use(requireByPath(parserPlugins));
+}
+
+const compilerPlugins = (argv.c || argv.compilerPlugins)
+if (compilerPlugins) {
+  parser.compilerPlugins.push(...requireByPath(compilerPlugins));
+}
+
+function sanitize(data) {
+  return recursivelyProcessAll(parser.sanitizeUnredacted.bind(parser), data);
+}
+
+Promise.all([
+  ioUtils.readFromFileOrStdin(argv.r).then(ioUtils.parseAsSerialized),
+])
+  .then(sanitize)
+  .then(ioUtils.formatAsSerialized)
+  .then(ioUtils.writeToFileOrStdout.bind(ioUtils, argv.o));

--- a/test/integration/data/badformat/sanitized.json
+++ b/test/integration/data/badformat/sanitized.json
@@ -1,0 +1,6 @@
+{
+  "basic example": {
+    "link": "",
+    "list and links": ""
+  }
+}

--- a/test/integration/data/questions/sanitized.md
+++ b/test/integration/data/questions/sanitized.md
@@ -1,0 +1,3 @@
+![Algorithm][1]{ .center }
+
+[1]: http://code.org/curriculum/course1/1/vocab.png

--- a/test/integration/data/simplejson/sanitized.json
+++ b/test/integration/data/simplejson/sanitized.json
@@ -1,0 +1,12 @@
+{
+  "basic example": {
+    "link": "",
+    "list and links": "",
+    "newline": "This is some text with a trailing newline",
+    "array": [
+      "And this",
+      "is an array",
+      ""
+    ]
+  }
+}

--- a/test/integration/scripts.test.js
+++ b/test/integration/scripts.test.js
@@ -1,45 +1,71 @@
 const expect = require('expect');
 const fs = require('fs');
 const path = require('path');
-const { spawnSync } = require('child_process');
+const {spawnSync} = require('child_process');
 
 const rootDir = path.resolve(__dirname, '..', '..');
 const dataDir = path.resolve(rootDir, 'test', 'integration', 'data');
 
-describe("Command-Line Scripts", () => {
+describe('Command-Line Scripts', () => {
   fs.readdirSync(dataDir).forEach(example => {
-    const sources = fs.readdirSync(path.resolve(dataDir, example)).filter(file => /^source.*$/.test(file));
+    const sources = fs
+      .readdirSync(path.resolve(dataDir, example))
+      .filter(file => /^source.*$/.test(file));
     sources.forEach(source => {
       describe(example, () => {
-        const extension = path.extname(source)
+        const extension = path.extname(source);
         const sourcePath = path.resolve(dataDir, example, source);
-        const redactedPath = path.resolve(dataDir, example, 'redacted' + extension)
-        const translatedPath = path.resolve(dataDir, example, 'translated' + extension)
-        const restoredPath = path.resolve(dataDir, example, 'restored' + extension)
-        const normalizedPath = path.resolve(dataDir, example, 'normalized' + extension)
-        const pluginPath = path.resolve(dataDir, example, 'plugin.js')
+        const redactedPath = path.resolve(
+          dataDir,
+          example,
+          'redacted' + extension
+        );
+        const translatedPath = path.resolve(
+          dataDir,
+          example,
+          'translated' + extension
+        );
+        const restoredPath = path.resolve(
+          dataDir,
+          example,
+          'restored' + extension
+        );
+        const normalizedPath = path.resolve(
+          dataDir,
+          example,
+          'normalized' + extension
+        );
+        const sanitizedPath = path.resolve(
+          dataDir,
+          example,
+          'sanitized' + extension
+        );
+        const pluginPath = path.resolve(dataDir, example, 'plugin.js');
 
         if (!fs.existsSync(redactedPath)) {
           return;
         }
 
-        describe("redact", () => {
-          const expected = fs.readFileSync(redactedPath, 'utf8')
+        describe('redact', () => {
+          const expected = fs.readFileSync(redactedPath, 'utf8');
 
-          it("redacts when given input as stdin", () => {
-            const input = fs.readFileSync(sourcePath, 'utf8')
+          it('redacts when given input as stdin', () => {
+            const input = fs.readFileSync(sourcePath, 'utf8');
             const args = [path.resolve(rootDir, 'src/bin/redact.js')];
             if (fs.existsSync(pluginPath)) {
               args.push('-p', pluginPath);
             }
             const redact = spawnSync('node', args, {
-              input
+              input,
             });
             expect(redact.stdout.toString()).toEqual(expected);
           });
 
-          it("redacts when given input as filepath", () => {
-            const args = [path.resolve(rootDir, 'src/bin/redact.js'), sourcePath];
+          it('redacts when given input as filepath', () => {
+            const args = [
+              path.resolve(rootDir, 'src/bin/redact.js'),
+              sourcePath
+            ];
             if (fs.existsSync(pluginPath)) {
               args.push('-p', pluginPath);
             }
@@ -48,28 +74,40 @@ describe("Command-Line Scripts", () => {
           });
         });
 
-        describe("restore", () => {
-          it("restores", () => {
+        describe('restore', () => {
+          it('restores', () => {
             // We sometimes want to be able to test special translation special cases,
             // so we support using special "translated" and "restored" data when they
             // are defined, but we generally just default to validating that the
             // restoration gets us back to the original
-            const expected = fs.existsSync(restoredPath) ? restoredPath : sourcePath;
-            const target = fs.existsSync(translatedPath) ? translatedPath : redactedPath;
-            const args = [path.resolve(rootDir, 'src/bin/restore.js'), '-s', sourcePath, '-r', target];
+            const expected = fs.existsSync(restoredPath)
+              ? restoredPath
+              : sourcePath;
+            const target = fs.existsSync(translatedPath)
+              ? translatedPath
+              : redactedPath;
+            const args = [
+              path.resolve(rootDir, 'src/bin/restore.js'),
+              '-s',
+              sourcePath,
+              '-r',
+              target,
+            ];
             if (fs.existsSync(pluginPath)) {
               args.push('-p', pluginPath);
             }
             const restore = spawnSync('node', args);
-            expect(restore.stdout.toString()).toEqual(fs.readFileSync(expected, 'utf8'));
+            expect(restore.stdout.toString()).toEqual(
+              fs.readFileSync(expected, 'utf8')
+            );
           });
         });
 
-        describe("normalize", () => {
-          const source = fs.readFileSync(sourcePath, 'utf8')
+        describe('normalize', () => {
+          const source = fs.readFileSync(sourcePath, 'utf8');
           let testname, expected;
           if (fs.existsSync(normalizedPath)) {
-            testname = "normalization will format source";
+            testname = 'normalization will format source';
             expected = fs.readFileSync(normalizedPath, 'utf8');
           } else {
             testname = "normalization doesn't change source";
@@ -82,9 +120,48 @@ describe("Command-Line Scripts", () => {
               args.push('-p', pluginPath);
             }
             const normalize = spawnSync('node', args, {
-              input: source
+              input: source,
             });
             expect(normalize.stdout.toString()).toEqual(expected);
+          });
+        });
+
+        describe('sanitize', () => {
+          const redacted = fs.readFileSync(redactedPath, 'utf8');
+          let sanitized_expected;
+          if (fs.existsSync(sanitizedPath)) {
+            sanitized_expected = fs.readFileSync(sanitizedPath, 'utf8');
+          } else {
+            sanitized_expected = '';
+          }
+          it('doesnt affect redacted content', () => {
+            const args = [
+              path.resolve(rootDir, 'src/bin/sanitize.js'),
+              '-r',
+              redactedPath
+            ];
+
+            if (fs.existsSync(pluginPath)) {
+              args.push('-p', pluginPath);
+            }
+            const sanitize = spawnSync('node', args);
+
+            expect(sanitize.stdout.toString()).toEqual(redacted);
+          });
+
+          it('removed unredacted content', () => {
+            const args = [
+              path.resolve(rootDir, 'src/bin/sanitize.js'),
+              '-r',
+              sourcePath
+            ];
+
+            if (fs.existsSync(pluginPath)) {
+              args.push('-p', pluginPath);
+            }
+            const sanitize = spawnSync('node', args);
+
+            expect(sanitize.stdout.toString()).toEqual(sanitized_expected);
           });
         });
       });

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -112,4 +112,18 @@ describe('Standard Markdown', () => {
       expect(output).toEqual("<p>C'est du texte avec <a href=\"http://example.com/\">un lien</a> et [une image][1]</p>\n");
     });
   });
+
+  describe('sanitize', () => {
+    it('will not change completely redacted input', () => {
+      const redacted = "C'est du texte avec [un lien][0] et [une image][1]";
+      const output = parser.sanitizeUnredacted(redacted);
+      expect(output).toEqual("C'est du texte avec [un lien][0] et [une image][1]\n");
+    });
+
+    it('will clear unredacted input', () => {
+      const unredacted = "This is some text with [a link](http://example.com/)";
+      const output = parser.sanitizeUnredacted(unredacted);
+      expect(output).toEqual('');
+    });
+  });
 });


### PR DESCRIPTION
This is useful for checking for incorrectly modified strings.

This works by checking to see if there are further redactions to the string provided. If there are, a new `redaction` node will be in the tree. If a `redaction` node exists then the string is rejected.

The benefit of this approach is that it comes for free with every plugin without extra work on the plugin maintainer. The downside is that it is a destructive operation (`sanitize` was used as the command to convey this, though I am open to other naming suggestions).