### PR TITLE
rename RedactableMarkdownParser to RedactableMarkdownProcessor

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -1,7 +1,7 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 
-const parser = require('../src/redactableMarkdownParser').create();
+const processor = require('../src/redactableMarkdownProcessor').create();
 
 //const initialMarkdown = require('./cdo-markdown.md');
 const initialMarkdown = "This is some text with [a link](http://first.com) and ![an image](http://second.com/img.jpg).\n\nAnd also a second paragraph with [another link](http://third.com)";
@@ -11,7 +11,7 @@ class Demo extends React.Component {
     super();
     this.state = {
       sourceMarkdown: initialMarkdown,
-      redactedMarkdown: parser.sourceToRedacted(initialMarkdown),
+      redactedMarkdown: processor.sourceToRedacted(initialMarkdown),
     };
   }
 
@@ -29,7 +29,7 @@ class Demo extends React.Component {
 
   redact = () => {
     this.setState({
-      redactedMarkdown: parser.sourceToRedacted(
+      redactedMarkdown: processor.sourceToRedacted(
         this.state.sourceMarkdown,
       ),
     });
@@ -74,13 +74,13 @@ class Demo extends React.Component {
         <div
           style={this.styles.renderContainer}
           dangerouslySetInnerHTML={{
-            __html: parser.sourceToHtml(this.state.sourceMarkdown)
+            __html: processor.sourceToHtml(this.state.sourceMarkdown)
           }}
         />
         <div
           style={this.styles.renderContainer}
           dangerouslySetInnerHTML={{
-            __html: parser.sourceAndRedactedToHtml(
+            __html: processor.sourceAndRedactedToHtml(
                 this.state.sourceMarkdown,
                 this.state.redactedMarkdown,
               )

--- a/src/bin/normalize.js
+++ b/src/bin/normalize.js
@@ -3,7 +3,7 @@
 const parseArgs = require('minimist');
 
 const ioUtils = require('../utils/io');
-const parser = require('../redactableMarkdownParser').create();
+const processor = require('../redactableMarkdownProcessor').create();
 const recursivelyProcessAll = require('../utils/misc').recursivelyProcessAll;
 const requireByPath = require('../utils/misc').requireByPath;
 
@@ -27,16 +27,16 @@ if (helpFlag) {
 
 const parserPlugins = (argv.p || argv.parserPlugins)
 if (parserPlugins) {
-  parser.parser.use(requireByPath(parserPlugins));
+  processor.processor.use(requireByPath(parserPlugins));
 }
 
 const compilerPlugins = (argv.c || argv.compilerPlugins)
 if (compilerPlugins) {
-  parser.compilerPlugins.push(...requireByPath(compilerPlugins));
+  processor.compilerPlugins.push(...requireByPath(compilerPlugins));
 }
 
 function normalize(data) {
-  return recursivelyProcessAll(parser.sourceToMarkdown.bind(parser), data);
+  return recursivelyProcessAll(processor.sourceToMarkdown.bind(processor), data);
 }
 
 ioUtils.readFromFileOrStdin(argv._[0])

--- a/src/bin/parse.js
+++ b/src/bin/parse.js
@@ -3,7 +3,7 @@
 const parseArgs = require('minimist');
 
 const ioUtils = require('../utils/io');
-const parser = require('../redactableMarkdownParser').create();
+const processor = require('../redactableMarkdownProcessor').create();
 const recursivelyProcessAll = require('../utils/misc').recursivelyProcessAll;
 const requireByPath = require('../utils/misc').requireByPath;
 
@@ -27,16 +27,16 @@ if (helpFlag) {
 
 const parserPlugins = (argv.p || argv.parserPlugins)
 if (parserPlugins) {
-  parser.parser.use(requireByPath(parserPlugins));
+  processor.processor.use(requireByPath(parserPlugins));
 }
 
 const compilerPlugins = (argv.c || argv.compilerPlugins)
 if (compilerPlugins) {
-  parser.compilerPlugins.push(...requireByPath(compilerPlugins));
+  processor.compilerPlugins.push(...requireByPath(compilerPlugins));
 }
 
 function parse(data) {
-  return recursivelyProcessAll(parser.sourceToMdast.bind(parser), data);
+  return recursivelyProcessAll(processor.sourceToMdast.bind(processor), data);
 }
 
 ioUtils.readFromFileOrStdin(argv._[0])

--- a/src/bin/redact.js
+++ b/src/bin/redact.js
@@ -3,7 +3,7 @@
 const parseArgs = require('minimist');
 
 const ioUtils = require('../utils/io');
-const parser = require('../redactableMarkdownParser').create();
+const processor = require('../redactableMarkdownProcessor').create();
 const recursivelyProcessAll = require('../utils/misc').recursivelyProcessAll;
 const requireByPath = require('../utils/misc').requireByPath;
 
@@ -27,16 +27,16 @@ if (helpFlag) {
 
 const parserPlugins = (argv.p || argv.parserPlugins)
 if (parserPlugins) {
-  parser.parser.use(requireByPath(parserPlugins));
+  processor.processor.use(requireByPath(parserPlugins));
 }
 
 const compilerPlugins = (argv.c || argv.compilerPlugins)
 if (compilerPlugins) {
-  parser.compilerPlugins.push(...requireByPath(compilerPlugins));
+  processor.compilerPlugins.push(...requireByPath(compilerPlugins));
 }
 
 function redact(data) {
-  return recursivelyProcessAll(parser.sourceToRedacted.bind(parser), data);
+  return recursivelyProcessAll(processor.sourceToRedacted.bind(processor), data);
 }
 
 ioUtils.readFromFileOrStdin(argv._[0])

--- a/src/bin/render.js
+++ b/src/bin/render.js
@@ -3,7 +3,7 @@
 const parseArgs = require('minimist');
 
 const ioUtils = require('../utils/io');
-const parser = require('../redactableMarkdownParser').create();
+const processor = require('../redactableMarkdownProcessor').create();
 const recursivelyProcessAll = require('../utils/misc').recursivelyProcessAll;
 const requireByPath = require('../utils/misc').requireByPath;
 
@@ -27,16 +27,16 @@ if (helpFlag) {
 
 const parserPlugins = (argv.p || argv.parserPlugins)
 if (parserPlugins) {
-  parser.parser.use(requireByPath(parserPlugins));
+  processor.processor.use(requireByPath(parserPlugins));
 }
 
 const compilerPlugins = (argv.c || argv.compilerPlugins)
 if (compilerPlugins) {
-  parser.compilerPlugins.push(...requireByPath(compilerPlugins));
+  processor.compilerPlugins.push(...requireByPath(compilerPlugins));
 }
 
 function render(data) {
-  return recursivelyProcessAll(parser.sourceToHtml.bind(parser), data);
+  return recursivelyProcessAll(processor.sourceToHtml.bind(processor), data);
 }
 
 ioUtils.readFromFileOrStdin(argv._[0])

--- a/src/bin/restore.js
+++ b/src/bin/restore.js
@@ -3,7 +3,7 @@
 const parseArgs = require('minimist');
 
 const ioUtils = require('../utils/io');
-const parser = require('../redactableMarkdownParser').create();
+const processor = require('../redactableMarkdownProcessor').create();
 const recursivelyProcessAll = require('../utils/misc').recursivelyProcessAll;
 const requireByPath = require('../utils/misc').requireByPath;
 
@@ -23,16 +23,16 @@ if (helpFlag || missingRequiredFlags) {
 
 const parserPlugins = (argv.p || argv.parserPlugins)
 if (parserPlugins) {
-  parser.parser.use(requireByPath(parserPlugins));
+  processor.processor.use(requireByPath(parserPlugins));
 }
 
 const compilerPlugins = (argv.c || argv.compilerPlugins)
 if (compilerPlugins) {
-  parser.compilerPlugins.push(...requireByPath(compilerPlugins));
+  processor.compilerPlugins.push(...requireByPath(compilerPlugins));
 }
 
 function restore(data) {
-  return recursivelyProcessAll(parser.sourceAndRedactedToMarkdown.bind(parser), data);
+  return recursivelyProcessAll(processor.sourceAndRedactedToMarkdown.bind(processor), data);
 }
 
 Promise.all([

--- a/src/redactableMarkdownProcessor.js
+++ b/src/redactableMarkdownProcessor.js
@@ -19,28 +19,28 @@ const remarkOptions = {
   pedantic: true
 };
 
-module.exports = class RedactableMarkdownParser {
+module.exports = class RedactableMarkdownProcessor {
 
   constructor() {
     this.compilerPlugins = this.constructor.getCompilerPlugins();
-    this.parser = unified()
+    this.processor = unified()
       .use(parse, remarkOptions)
       .use(this.constructor.getParserPlugins());
   }
 
-  getParser() {
-    return this.parser();
+  getProcessor() {
+    return this.processor();
   }
 
   sourceToHtml(source) {
-    return this.getParser()
+    return this.getProcessor()
       .use(html, remarkOptions)
       .processSync(source)
       .contents;
   }
 
   sourceToMarkdown(source) {
-    return this.getParser()
+    return this.getProcessor()
       .use(stringify, remarkOptions)
       .use(this.compilerPlugins)
       .processSync(source)
@@ -48,19 +48,19 @@ module.exports = class RedactableMarkdownParser {
   }
 
   sourceToMdast(source) {
-    return this.getParser()
+    return this.getProcessor()
       .parse(source);
   }
 
   sourceToRedactedMdast(source) {
-    return this.getParser()
+    return this.getProcessor()
       .use({ settings: { redact: true } })
       .parse(source);
   }
 
   sourceToRedacted(source) {
     const sourceTree = this.sourceToRedactedMdast(source);
-    return this.getParser()
+    return this.getProcessor()
       .use(stringify, remarkOptions)
       .use(renderRedactions)
       .use(this.compilerPlugins)
@@ -69,7 +69,7 @@ module.exports = class RedactableMarkdownParser {
 
   sourceAndRedactedToMergedMdast(source, redacted) {
     const sourceTree = this.sourceToRedactedMdast(source);
-    const redactedTree = this.getParser()
+    const redactedTree = this.getProcessor()
       .use(restoreRedactions(sourceTree))
       .parse(redacted);
 
@@ -78,7 +78,7 @@ module.exports = class RedactableMarkdownParser {
 
   sourceAndRedactedToMarkdown(source, redacted) {
     const mergedMdast = this.sourceAndRedactedToMergedMdast(source, redacted);
-    return this.getParser()
+    return this.getProcessor()
       .use(stringify, remarkOptions)
       .use(this.compilerPlugins)
       .stringify(mergedMdast);
@@ -106,6 +106,6 @@ module.exports = class RedactableMarkdownParser {
   }
 
   static create() {
-    return new RedactableMarkdownParser();
+    return new RedactableMarkdownProcessor();
   }
 };

--- a/test/unit/plugins/compiler/betterPedanticEmphasis.test.js
+++ b/test/unit/plugins/compiler/betterPedanticEmphasis.test.js
@@ -3,12 +3,12 @@
  */
 
 const expect = require('expect');
-const parser = require('../../../../src/redactableMarkdownParser').create();
+const processor = require('../../../../src/redactableMarkdownProcessor').create();
 
 describe('pedantic emphasis', () => {
   it('should handle underscores in emphasis in pedantic mode', () => {
     const example = '*alpha_bravo*\n';
-    expect(parser.sourceToMarkdown(example)).toEqual('*alpha\\_bravo*\n');
+    expect(processor.sourceToMarkdown(example)).toEqual('*alpha\\_bravo*\n');
   });
 
   describe('emphasis in pedantic mode should support a constiety of contained inline content', () => {
@@ -25,7 +25,7 @@ describe('pedantic emphasis', () => {
     ];
     tests.forEach(function (test) {
       it(test[0], () => {
-        expect(parser.sourceToMarkdown(test[1])).toEqual(test[2]);
+        expect(processor.sourceToMarkdown(test[1])).toEqual(test[2]);
       });
     });
   });

--- a/test/unit/plugins/parser/divclass.test.js
+++ b/test/unit/plugins/parser/divclass.test.js
@@ -1,48 +1,48 @@
 const expect = require('expect');
-const parser = require('../../../../src/redactableMarkdownParser').create();
+const processor = require('../../../../src/redactableMarkdownProcessor').create();
 
 describe('divclass', () => {
   describe('render', () => {
     it('renders a basic divclass', () => {
       const input = "[col-33]\n\nsimple content\n\n[/col-33]";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<div class=\"col-33\"><p>simple content</p></div>\n");
     });
 
     it('renders a basic divclass even with a bunch of extra whitespace', () => {
       const input = "[col-33]   \n \nsimple content\n  \n     [/col-33]";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<div class=\"col-33\"><p>simple content</p></div>\n");
     });
 
     it('works without content - but only if separated by FOUR newlines', () => {
       const validInput = "[empty]\n\n\n\n[/empty]";
-      expect(parser.sourceToHtml(validInput)).toEqual("<div class=\"empty\"></div>\n");
+      expect(processor.sourceToHtml(validInput)).toEqual("<div class=\"empty\"></div>\n");
       const invalidInput = "[empty]\n\n[/empty]";
-      expect(parser.sourceToHtml(invalidInput)).toEqual("<p>[empty]</p>\n<p>[/empty]</p>\n");
+      expect(processor.sourceToHtml(invalidInput)).toEqual("<p>[empty]</p>\n<p>[/empty]</p>\n");
     });
 
     it('renders a divclass within other content', () => {
       const input = "outside of div\n\n[divname]\n\ninside div\n\n[/divname]\n\nmore outside";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<p>outside of div</p>\n<div class=\"divname\"><p>inside div</p></div>\n<p>more outside</p>\n");
     });
 
     it("doesn't care about duplicate classes", () => {
       const input = "[classname]\n\nfirst\n\n[/classname]\n\n[classname]\n\nsecond\n\n[/classname]";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<div class=\"classname\"><p>first</p></div>\n<div class=\"classname\"><p>second</p></div>\n");
     });
 
     it('can nest divclasses', () => {
       const input = "[outer]\n\n[inner]\n\nnested\n\n[/inner]\n\n[/outer]";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<div class=\"outer\"><div class=\"inner\"><p>nested</p></div></div>\n");
     });
 
     it('can nest duplicate divclasses', () => {
       const input = "[classname]\n\ncontent\n\n[classname]\n\ninner content\n\n[/classname]\n\ncontent\n\n[/classname]";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<div class=\"classname\"><p>content</p><div class=\"classname\"><p>inner content</p></div><p>content</p></div>\n");
     });
 
@@ -59,31 +59,31 @@ describe('divclass', () => {
       for (let _ = 0; _ < 20; _++) {
         input = `${markdownOpen}${input}${markdownClose}`;
         output = `${htmlOpen}${output}${htmlClose}`;
-        expect(parser.sourceToHtml(input)).toEqual(output + "\n");
+        expect(processor.sourceToHtml(input)).toEqual(output + "\n");
       }
     });
 
     it('requires class-specific termination', () => {
       const input = "[example]\n\nsimple content\n\n[/]";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<p>[example]</p>\n<p>simple content</p>\n<p>[/]</p>\n");
     });
 
     it('requires divclasses be in their own paragraphs', () => {
       const input = "[example]simple content[/example]";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<p>[example]simple content[/example]</p>\n");
     });
 
     it('will not unindent', () => {
       const input = "[example]\n\n    simple content\n\n[/example]";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<div class=\"example\"><pre><code>simple content\n</code></pre></div>\n");
     });
 
     it('can render complex content inside a divclass', () => {
       const input = "[complex-example]\n\n-   an ordered list\n-   with **inline** _formatting_, too\n\n[/complex-example]";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<div class=\"complex-example\"><ul>\n<li>an ordered list</li>\n<li>with <strong>inline</strong> <em>formatting</em>, too</li>\n</ul></div>\n");
     });
   });
@@ -91,37 +91,37 @@ describe('divclass', () => {
   describe('redact', () => {
     it('redacts a basic divclass', () => {
       const input = "[col-33]\n\nsimple content\n\n[/col-33]";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("[][0]\n\nsimple content\n\n[/][0]\n");
     });
 
     it('works without content - but only if separated by FOUR newlines', () => {
       const input = "[empty]\n\n\n\n[/empty]";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("[][0]\n\n[/][0]\n");
     });
 
     it('renders a divclass within other content', () => {
       const input = "outside of div\n\n[divname]\n\ninside div\n\n[/divname]\n\nmore outside";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("outside of div\n\n[][0]\n\ninside div\n\n[/][0]\n\nmore outside\n");
     });
 
     it("doesn't care about duplicate classes", () => {
       const input = "[classname]\n\nfirst\n\n[/classname]\n\n[classname]\n\nsecond\n\n[/classname]";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("[][0]\n\nfirst\n\n[/][0]\n\n[][1]\n\nsecond\n\n[/][1]\n");
     });
 
     it('can redact nested divclasses', () => {
       const input = "[outer]\n\n[inner]\n\nnested\n\n[/inner]\n\n[/outer]";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("[][0]\n\n[][1]\n\nnested\n\n[/][1]\n\n[/][0]\n");
     });
 
     it('can redact inline content inside a divclass', () => {
       const input = "[complex-example]\n\n-   an ordered list\n-   with [other redacted content](http://example.com)\n\n[/complex-example]";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("[][0]\n\n-   an ordered list\n-   with [other redacted content][1]\n\n[/][0]\n");
     });
   });
@@ -130,35 +130,35 @@ describe('divclass', () => {
     it('can restore basic divclasses back to markdown', () => {
       const source = "[col-33]\n\nsimple content\n\n[/col-33]";
       const redacted = "[][0]\n\ncontenu simple\n\n[/][0]\n";
-      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      const output = processor.sourceAndRedactedToMarkdown(source, redacted);
       expect(output).toEqual("[col-33]\n\ncontenu simple\n\n[/col-33]\n");
     });
 
     it('can restore basic divclasses', () => {
       const source = "[col-33]\n\nsimple content\n\n[/col-33]";
       const redacted = "[][0]\n\ncontenu simple\n\n[/][0]\n";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<div class=\"col-33\"><p>contenu simple</p></div>\n");
     });
 
     it('can restore nested divclasses', () => {
       const source = "[outer]\n\n[inner]\n\nnested\n\n[/inner]\n\n[/outer]";
       const redacted = "[][0]\n\n[][1]\n\nimbriqué\n\n[/][1]\n\n[/][0]\n";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<div class=\"outer\"><div class=\"inner\"><p>imbriqué</p></div></div>\n");
     });
 
     it('can restore inline content inside a divclass', () => {
       const source = "[complex-example]\n\n-   an ordered list\n-   with [other redacted content](http://example.com)\n\n[/complex-example]";
       const redacted = "[][0]\n\n-   une liste ordonnée\n-   avec [d'autres contenus rédigés][1]\n\n[/][0]\n";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<div class=\"complex-example\"><ul>\n<li>une liste ordonnée</li>\n<li>avec <a href=\"http://example.com\">d'autres contenus rédigés</a></li>\n</ul></div>\n");
     });
 
     it('can restore content with reordered indexes', () => {
       const source = "[zero]\n\nzero\n\n[/zero]\n\n[one]\n\none\n\n[/one]";
       const redacted = "[][1]\n\nun\n\n[/][1]\n\n[][0]\n\nzéro\n\n[/][0]";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<div class=\"one\"><p>un</p></div>\n<div class=\"zero\"><p>zéro</p></div>\n");
     });
 
@@ -166,15 +166,15 @@ describe('divclass', () => {
       const source = "[zero]\n\n[one]\n\n\n\n[/one]\n\n[/zero]"
 
       const unNestedRedaction = "[][0]\n\n\n\n[/][0]\n\n[][1]\n\n\n\n[/][1]";
-      expect(parser.sourceAndRedactedToHtml(source, unNestedRedaction))
+      expect(processor.sourceAndRedactedToHtml(source, unNestedRedaction))
         .toEqual("<div class=\"zero\"></div>\n<div class=\"one\"></div>\n");
 
       const invertedRedaction = "[][1]\n\n[][0]\n\n\n\n[/][0]\n\n[/][1]";
-      expect(parser.sourceAndRedactedToHtml(source, invertedRedaction))
+      expect(processor.sourceAndRedactedToHtml(source, invertedRedaction))
         .toEqual("<div class=\"one\"><div class=\"zero\"></div></div>\n");
 
       const brokenRedaction = "[][0]\n\n[][1]\n\n\n\n[/][0]\n\n[/][1]"
-      expect(parser.sourceAndRedactedToHtml(source, brokenRedaction))
+      expect(processor.sourceAndRedactedToHtml(source, brokenRedaction))
         .toEqual("<div class=\"zero\"><p>[][1]</p></div>\n<p>[/][1]</p>\n");
     });
 
@@ -182,19 +182,19 @@ describe('divclass', () => {
       const source = "[first]\n\nFirst\n\n[/first]\n\n[second]\n\nSecond\n\n[/second]";
 
       const reusedIndex = "[][0]\n\nPremier\n\n[/][0]\n\n[][1]\n\nDeuxième\n\n[/][1]\n\n[][1]\n\nTroisième\n\n[/][1]"
-      expect(parser.sourceAndRedactedToHtml(source, reusedIndex))
+      expect(processor.sourceAndRedactedToHtml(source, reusedIndex))
         .toEqual("<div class=\"first\"><p>Premier</p></div>\n<div class=\"second\"><p>Deuxième</p></div>\n<div class=\"second\"><p>Troisième</p></div>\n");
 
       // in every case, extra redactions default to raw markdown
       const extraIndex = "[][0]\n\nPremier\n\n[/][0]\n\n[][1]\n\nDeuxième\n\n[/][1]\n\n[][2]\n\nTroisième\n\n[/][2]"
-      expect(parser.sourceAndRedactedToHtml(source, extraIndex))
+      expect(processor.sourceAndRedactedToHtml(source, extraIndex))
         .toEqual("<div class=\"first\"><p>Premier</p></div>\n<div class=\"second\"><p>Deuxième</p></div>\n<p>[][2]</p>\n<p>Troisième</p>\n<p>[/][2]</p>\n");
     });
 
     it('can NOT restore content if required whitespace is removed', () => {
       const source = "[clazz]\n\nCat\n\n[/clazz]";
       const redacted = "[][0]\nChat\n[/][0]";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<p>[][0]\nChat\n[/][0]</p>\n");
     });
   });

--- a/test/unit/plugins/parser/paragraph.test.js
+++ b/test/unit/plugins/parser/paragraph.test.js
@@ -1,19 +1,19 @@
 const expect = require('expect');
-const parser = require('../../../../src/redactableMarkdownParser').create();
+const processor = require('../../../../src/redactableMarkdownProcessor').create();
 
 describe('paragraph', () => {
   describe('render', () => {
     it('renders paragraphs separated by < 4 spaces as two paragraphs', () => {
       for (let i = 0; i < 4; i++) {
         const input = `First Paragraph\n${' '.repeat(i)}\nSecondParagraph`
-        const output = parser.sourceToHtml(input);
+        const output = processor.sourceToHtml(input);
         expect(output).toEqual("<p>First Paragraph</p>\n<p>SecondParagraph</p>\n");
       }
     });
     it('renders paragraphs separated by >= 4 spaces as two paragraphs', () => {
       for (let i = 4; i < 20; i++) {
         const input = `First Paragraph\n${' '.repeat(i)}\nSecondParagraph`
-        const output = parser.sourceToHtml(input);
+        const output = processor.sourceToHtml(input);
         expect(output).toEqual("<p>First Paragraph</p>\n<p>SecondParagraph</p>\n");
       }
     });

--- a/test/unit/plugins/parser/resourcelink.test.js
+++ b/test/unit/plugins/parser/resourcelink.test.js
@@ -1,13 +1,13 @@
 const expect = require('expect');
-const parser = require('../../../../src/redactableMarkdownParser').create();
+const processor = require('../../../../src/redactableMarkdownProcessor').create();
 const resourcelinkPlugin = require('./resourcelink');
-parser.parser.use(resourcelinkPlugin);
+processor.processor.use(resourcelinkPlugin);
 
 describe('resourcelink', () => {
   describe('render', () => {
     it('cannot render resourcelinks to html', () => {
       const input = "[r some-slug]";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<p>[r some-slug]</p>\n");
     });
   });
@@ -15,7 +15,7 @@ describe('resourcelink', () => {
   describe('redact', () => {
     it('redacts resourcelinks', () => {
       const input = "[r some-slug]";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("[some-slug][0]\n");
     });
   });
@@ -24,7 +24,7 @@ describe('resourcelink', () => {
     it('can restore resourcelinks back to markdown', () => {
       const source = "[r some-slug]";
       const redacted = "[any-text][0]"
-      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      const output = processor.sourceAndRedactedToMarkdown(source, redacted);
       expect(output).toEqual("[r some-slug]\n");
     });
 
@@ -33,7 +33,7 @@ describe('resourcelink', () => {
       // this is true
       const source = "[r some-slug]";
       const redacted = "[any-text][0]"
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<p>[r some-slug]</p>\n");
     });
   });

--- a/test/unit/plugins/parser/tip.test.js
+++ b/test/unit/plugins/parser/tip.test.js
@@ -1,13 +1,13 @@
 const expect = require('expect');
-const parser = require('../../../../src/redactableMarkdownParser').create();
+const processor = require('../../../../src/redactableMarkdownProcessor').create();
 const tipPlugin = require('./tip');
-parser.parser.use(tipPlugin);
+processor.processor.use(tipPlugin);
 
 describe('tip', () => {
   describe('render', () => {
     it('renders a basic tip', () => {
       const input = "!!!tip \"this is an optional title, and it should be translatable\" <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       /**
        * <div class="admonition tip">
        *   <p class="admonition-title" id="tip_tip-0">
@@ -28,7 +28,7 @@ describe('tip', () => {
 
     it('renders a basic tip even with weird indentation', () => {
       const input = "!!!tip \"this is an optional title, and it should be translatable\" <tip-0>\n\tThis is the content of the tip, and it should be translatable, as should all the following blocks:\n \tone\n\t\t\t\ttwo\n \t three\n              four\n\nThis is the next paragraph";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       /**
        * <div class="admonition tip">
        *   <p class="admonition-title" id="tip_tip-0">
@@ -50,21 +50,21 @@ describe('tip', () => {
 
     it('renders a basic tip without an id', () => {
       const input = "!!!tip \"this is an optional title, and it should be translatable\"\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       const expected = "<div class=\"admonition tip\"><p class=\"admonition-title\"><i class=\"fa fa-lightbulb-o\"></i>this is an optional title, and it should be translatable</p><div><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div></div>\n<p>This is the next paragraph</p>\n"
       expect(output).toEqual(expected);
     });
 
     it('renders a basic tip without a title', () => {
       const input = "!!!tip <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       const expected = "<div class=\"admonition tip\"><p class=\"admonition-title\" id=\"tip_tip-0\"><i class=\"fa fa-lightbulb-o\"></i></p><div><p>This is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip</p></div></div>\n<p>This is the next paragraph</p>\n"
       expect(output).toEqual(expected);
     });
 
     it('renders a tip with multiple children', () => {
       const input = "!!!tip \"this is an optional title, and it should be translatable\" <tip-0>\n    This is the content of the tip, and it should be translatable\n\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       /**
        * <div class="admonition tip">
        *   <p class="admonition-title" id="tip_tip-0">
@@ -88,7 +88,7 @@ describe('tip', () => {
 
     it('renders a basic tip indented with tabs', () => {
       const input = "!!!tip \"this is an optional title, and it should be translatable\" <tip-0>\n\tThis is the content of the tip, and it should be translatable\n\tThis is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       /*
        <div class="admonition tip">
          <p class="admonition-title" id="tip_tip-0">
@@ -111,7 +111,7 @@ describe('tip', () => {
   describe('redact', () => {
     it('can redact a basic tip', () => {
       const input = "!!!tip \"this is an optional title, and it should be translatable\" <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       /**
        * [this is an optional title, and it should be translatable][0]
        * 
@@ -127,13 +127,13 @@ describe('tip', () => {
 
     it('can redact a basic tip without an id', () => {
       const input = "!!!tip \"this is an optional title, and it should be translatable\"\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("[this is an optional title, and it should be translatable][0]\n\nThis is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n");
     });
 
     it('can redact a basic tip without a title', () => {
       const input = "!!!tip <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("[][0]\n\nThis is the content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n");
     });
   });
@@ -142,7 +142,7 @@ describe('tip', () => {
     it('can restore a basic tip', () => {
       const source = "!!!tip \"this is an optional title, and it should be translatable\" <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
       const redacted = "[c'est une optional title, and it should be translatable][0]\n\nC'est du content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n";
-      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      const output = processor.sourceAndRedactedToMarkdown(source, redacted);
       const expected = "!!!tip \"c'est une optional title, and it should be translatable\" <tip-0>\n    C'est du content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph\n";
       expect(output).toEqual(expected);
     });
@@ -150,7 +150,7 @@ describe('tip', () => {
     it('can restore a basic tip with multiple children', () => {
       const source = "!!!tip \"this is an optional title, and it should be translatable\" <tip-0>\n    This is the content of the tip, and it should be translatable\n\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
       const redacted = "[c'est une optional title, and it should be translatable][0]\n\nC'est du content of the tip, and it should be translatable\n\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n";
-      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      const output = processor.sourceAndRedactedToMarkdown(source, redacted);
       const expected = "!!!tip \"c'est une optional title, and it should be translatable\" <tip-0>\n    C'est du content of the tip, and it should be translatable\n\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph\n";
       expect(output).toEqual(expected);
     });
@@ -158,7 +158,7 @@ describe('tip', () => {
     it('can restore a basic tip without an id', () => {
       const source = "!!!tip \"this is an optional title, and it should be translatable\"\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
       const redacted = "[c'est une optional title, and it should be translatable][0]\n\nC'est du content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n";
-      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      const output = processor.sourceAndRedactedToMarkdown(source, redacted);
       const expected = "!!!tip \"c'est une optional title, and it should be translatable\"\n    C'est du content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph\n";
       expect(output).toEqual(expected);
     });
@@ -166,7 +166,7 @@ describe('tip', () => {
     it('can restore a basic tip without a title', () => {
       const source = "!!!tip <tip-0>\n    This is the content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph";
       const redacted = "[][0]\n\nC'est du content of the tip, and it should be translatable\nThis is more stuff that is still part of the content of the tip\n\n[/][0]\n\nThis is the next paragraph\n";
-      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      const output = processor.sourceAndRedactedToMarkdown(source, redacted);
       const expected = "!!!tip <tip-0>\n    C'est du content of the tip, and it should be translatable\n    This is more stuff that is still part of the content of the tip\n\nThis is the next paragraph\n";
       expect(output).toEqual(expected);
     });

--- a/test/unit/plugins/parser/tiplink.test.js
+++ b/test/unit/plugins/parser/tiplink.test.js
@@ -1,7 +1,7 @@
 const expect = require('expect');
-const parser = require('../../../../src/redactableMarkdownParser').create();
+const processor = require('../../../../src/redactableMarkdownProcessor').create();
 const tiplinkPlugin = require('./tiplink');
-parser.parser.use(tiplinkPlugin);
+processor.processor.use(tiplinkPlugin);
 
 describe('tiplink', () => {
   const basicTipMarkdown = "tip!!!";
@@ -16,31 +16,31 @@ describe('tiplink', () => {
   describe('render', () => {
     it('renders basic tiplink', () => {
       const input = basicTipMarkdown;
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual(`<p>${basicTipHtml}</p>\n`);
     });
 
     it('renders a tiplink no matter where it begins', () => {
       const input = `look, a ${basicTipMarkdown}`;
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual(`<p>look, a ${basicTipHtml}</p>\n`);
     });
 
     it('renders tiplink with label', () => {
       const input = labeledTipMarkdown;
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual(`<p>${labeledTipHtml}</p>\n`);
     });
 
     it('renders a tiplink with label no matter where it begins', () => {
       const input = `look, a ${labeledTipMarkdown}`;
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual(`<p>look, a ${labeledTipHtml}</p>\n`);
     });
 
     it('renders a tiplink with label with content after it', () => {
       const input = `look, a ${labeledTipMarkdown} cool, huh?`;
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual(`<p>look, a ${labeledTipHtml} cool, huh?</p>\n`);
     });
   });
@@ -48,19 +48,19 @@ describe('tiplink', () => {
   describe('redact', () => {
     it('redacts tiplinks', () => {
       const input = "This is some text with an inline labeled tip: " + labeledTipMarkdown;
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("This is some text with an inline labeled tip: [][0]\n");
     });
 
     it('redacts basic tiplinks', () => {
       const input = "This is some text with an inline labeled tip: " + basicTipMarkdown;
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("This is some text with an inline labeled tip: [][0]\n");
     });
 
     it('redacts basic discussion links', () => {
       const input = "This is some text with an inline labeled tip: " + basicDiscussionMarkdown;
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("This is some text with an inline labeled tip: [][0]\n");
     });
   });
@@ -69,28 +69,28 @@ describe('tiplink', () => {
     it('can restore tiplinks back to markdown', () => {
       const source = "This is some text with an inline labeled tip: " + labeledTipMarkdown;
       const redacted = "Ceci est un texte avec un [][0] inline labeled tip";
-      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      const output = processor.sourceAndRedactedToMarkdown(source, redacted);
       expect(output).toEqual("Ceci est un texte avec un tip!!! tip-0 inline labeled tip\n");
     });
 
     it('can translate tiplinks', () => {
       const source = "This is some text with an inline labeled tip: " + labeledTipMarkdown;
       const redacted = "Ceci est un texte avec un [][0] inline labeled tip";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<p>Ceci est un texte avec un " + labeledTipHtml + " inline labeled tip</p>\n");
     });
 
     it('can translate basic tiplinks', () => {
       const source = "This is some text with an inline labeled tip: " + basicTipMarkdown;
       const redacted = "Ceci est un texte avec un [][0] inline labeled tip";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<p>Ceci est un texte avec un " + basicTipHtml + " inline labeled tip</p>\n");
     });
 
     it('can translate basic discussion links', () => {
       const source = "This is some text with an inline labeled tip: " + basicDiscussionMarkdown;
       const redacted = "Ceci est un texte avec un [][0] inline labeled tip";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<p>Ceci est un texte avec un " + basicDiscussionHtml + " inline labeled tip</p>\n");
     });
   });

--- a/test/unit/plugins/parser/vocablink.test.js
+++ b/test/unit/plugins/parser/vocablink.test.js
@@ -1,15 +1,15 @@
 const expect = require('expect');
-const parser = require('../../../../src/redactableMarkdownParser').create();
+const processor = require('../../../../src/redactableMarkdownProcessor').create();
 const vocablinkPlugin = require('./vocablink');
-parser.parser.use(vocablinkPlugin);
+processor.processor.use(vocablinkPlugin);
 const mapMdast = require('../../../utils').mapMdast;
 
 describe('vocablink', () => {
   describe('parse', () => {
     it('can distinguish between vocablinks with word overrides and linkReferences', () => {
       // the only difference between these two bits of the syntax is the "v "
-      const vocablink = parser.getParser().parse("[v some-word][override]");
-      const linkReference = parser.getParser().parse("[some-word][override]");
+      const vocablink = processor.getProcessor().parse("[v some-word][override]");
+      const linkReference = processor.getProcessor().parse("[some-word][override]");
       expect(mapMdast(vocablink)).toEqual({
         children: [{ children: [{ type: 'rawtext' }], type: 'paragraph' }],
         type: 'root',
@@ -29,13 +29,13 @@ describe('vocablink', () => {
   describe('render', () => {
     it('can only render vocablinks back out to plain text', () => {
       const input = "[v some-word]";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<p>[v some-word]</p>\n");
     });
 
     it('can only render vocablinks with word overrides back out to plain text', () => {
       const input = "[v some-word][override]";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<p>[v some-word][override]</p>\n");
     });
   });
@@ -43,13 +43,13 @@ describe('vocablink', () => {
   describe('redact', () => {
     it('redacts vocablinks', () => {
       const input = "[v some-word]";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("[some-word][0]\n");
     });
 
     it('redacts vocablinks with word overrides', () => {
       const input = "[v some-word][un-mot]";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("[un-mot][0]\n");
     });
   });
@@ -58,14 +58,14 @@ describe('vocablink', () => {
     it('can restore vocablinks back to markdown', () => {
       const source = "[v some-word]";
       const redacted = "[un-mot][0]"
-      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      const output = processor.sourceAndRedactedToMarkdown(source, redacted);
       expect(output).toEqual("[v some-word][un-mot]\n");
     });
 
     it('can restore vocablinks with word overrides back to markdown', () => {
       const source = "[v some-word][source-override]";
       const redacted = "[redaction-override][0]"
-      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      const output = processor.sourceAndRedactedToMarkdown(source, redacted);
       expect(output).toEqual("[v some-word][redaction-override]\n");
     });
   });

--- a/test/unit/redactableMarkdownProcessor.test.js
+++ b/test/unit/redactableMarkdownProcessor.test.js
@@ -1,29 +1,29 @@
 const expect = require('expect');
-const parser = require('../../src/redactableMarkdownParser').create();
+const processor = require('../../src/redactableMarkdownProcessor').create();
 
 describe('Standard Markdown', () => {
   describe('render', () => {
     it('can render basic links', () => {
       const input = "This is some text with [a link](http://example.com)";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<p>This is some text with <a href=\"http://example.com\">a link</a></p>\n");
     });
 
     it('can render autolinks', () => {
       const input = "This is some text that automatically links to <http://example.com>";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<p>This is some text that automatically links to <a href=\"http://example.com\">http://example.com</a></p>\n");
     });
 
     it('can render sublists with tab characters', () => {
       const input = "- List item one.\n\n\t- Sublist item one\n\n\t- Sublist item two\n\n- List item two"
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<ul>\n<li>\n<p>List item one.</p>\n<ul>\n<li>\n<p>Sublist item one</p>\n</li>\n<li>\n<p>Sublist item two</p>\n</li>\n</ul>\n</li>\n<li>\n<p>List item two</p>\n</li>\n</ul>\n");
     });
 
     it('can render complex nested lists', () => {
       const input = "1.  List item one.\n\n    List item one continued with a second paragraph followed by an\n    Indented block.\n\n        $ ls *.sh\n        $ mv *.sh ~/tmp\n\n    List item continued with a third paragraph.\n\n2.  List item two continued with an open block.\n\n    This paragraph is part of the preceding list item.\n\n    1. This list is nested and does not require explicit item continuation.\n\n       This paragraph is part of the preceding list item.\n\n    2. List item b.\n\n    This paragraph belongs to item two of the outer list.";
-      const output = parser.sourceToHtml(input);
+      const output = processor.sourceToHtml(input);
       expect(output).toEqual("<ol>\n<li>\n<p>List item one.</p>\n<p>List item one continued with a second paragraph followed by an\nIndented block.</p>\n<pre><code>$ ls *.sh\n$ mv *.sh ~/tmp\n</code></pre>\n<p>List item continued with a third paragraph.</p>\n</li>\n<li>\n<p>List item two continued with an open block.</p>\n<p>This paragraph is part of the preceding list item.</p>\n<ol>\n<li>\n<p>This list is nested and does not require explicit item continuation.</p>\n<p>This paragraph is part of the preceding list item.</p>\n</li>\n<li>\n<p>List item b.</p>\n</li>\n</ol>\n<p>This paragraph belongs to item two of the outer list.</p>\n</li>\n</ol>\n");
     });
   });
@@ -31,19 +31,19 @@ describe('Standard Markdown', () => {
   describe('redact', () => {
     it('redacts link urls', () => {
       const input = "This is some text with [a link](http://example.com)";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("This is some text with [a link][0]\n");
     });
 
     it('redacts image urls', () => {
       const input = "This is some text with ![an image](http://example.com/img.jpg)";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("This is some text with [an image][0]\n");
     });
 
     it('redacts autolinks', () => {
       const input = "This is some text that automatically links to <http://example.com>";
-      const output = parser.sourceToRedacted(input);
+      const output = processor.sourceToRedacted(input);
       expect(output).toEqual("This is some text that automatically links to [http://example.com][0]\n");
     });
   });
@@ -52,63 +52,63 @@ describe('Standard Markdown', () => {
     it('can restore redacted links to markdown', () => {
       const source = "This is some text with [a link](http://example.com/)";
       const redacted = "Ceci est un texte avec [un lien][0]";
-      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      const output = processor.sourceAndRedactedToMarkdown(source, redacted);
       expect(output).toEqual("Ceci est un texte avec [un lien](http://example.com/)\n");
     });
 
     it('can restore redacted autolinks', () => {
       const source = "This is some text that automatically links to <http://example.com>";
       const redacted = "C'est du texte that automatically links to [http://example.com][0]\n";
-      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      const output = processor.sourceAndRedactedToMarkdown(source, redacted);
       expect(output).toEqual("C'est du texte that automatically links to <http://example.com>\n");
     });
 
     it('can restore redacted and altered autolinks', () => {
       const source = "This is some text that automatically links to <http://example.com>";
       const redacted = "C'est du texte that links to [this example][0]\n";
-      const output = parser.sourceAndRedactedToMarkdown(source, redacted);
+      const output = processor.sourceAndRedactedToMarkdown(source, redacted);
       expect(output).toEqual("C'est du texte that links to [this example](http://example.com)\n");
     });
 
     it('can restore redacted links to html', () => {
       const source = "This is some text with [a link](http://example.com/)";
       const redacted = "Ceci est un texte avec [un lien][0]";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<p>Ceci est un texte avec <a href=\"http://example.com/\">un lien</a></p>\n");
     });
 
     it('can restore redacted images', () => {
       const source = "This is some text with ![an image](http://example.com/img.jpg)";
       const redacted = "Ceci est un texte avec [une image][0]";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<p>Ceci est un texte avec <img src=\"http://example.com/img.jpg\" alt=\"une image\"></p>\n");
     });
 
     it('can differentiate between multiple redactons', () => {
       const source = "This is some text with [a link](http://first.com) and ![an image](http://second.com/img.jpg).\n\nAnd also a second paragraph with [another link](http://third.com)";
       const redacted = "C'est du texte avec [un lien][0] et [une image][1].\n\nEt aussi un deuxième paragraphe avec [un autre lien][2]";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<p>C'est du texte avec <a href=\"http://first.com\">un lien</a> et <img src=\"http://second.com/img.jpg\" alt=\"une image\">.</p>\n<p>Et aussi un deuxième paragraphe avec <a href=\"http://third.com\">un autre lien</a></p>\n");
     });
 
     it('can handle reordering of redactions', () => {
       const source = "The [black](http://first.com) [cat](http://second.com)."
       const redacted = "Le [chat][1] [noir][0]."
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<p>Le <a href=\"http://second.com\">chat</a> <a href=\"http://first.com\">noir</a>.</p>\n");
     });
 
     it('can handle removal of redactions', () => {
       const source = "This is some text with [a link](http://first.com) and ![an image](http://second.com/img.jpg).\n\nAnd also a second paragraph with [another link](http://third.com)";
       const redacted = "C'est du texte avec [un lien][0] et pas d'une image.\n\nEt aussi un deuxième paragraphe avec [un autre lien][2]";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<p>C'est du texte avec <a href=\"http://first.com\">un lien</a> et pas d'une image.</p>\n<p>Et aussi un deuxième paragraphe avec <a href=\"http://third.com\">un autre lien</a></p>\n");
     });
 
     it('will handle extra/unwanted redactions by treating them as references without definitions', () => {
       const source = "This is some text with [a link](http://example.com/)";
       const redacted = "C'est du texte avec [un lien][0] et [une image][1]";
-      const output = parser.sourceAndRedactedToHtml(source, redacted);
+      const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual("<p>C'est du texte avec <a href=\"http://example.com/\">un lien</a> et [une image][1]</p>\n");
     });
   });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  entry: './src/redactableMarkdownParser',
+  entry: './src/redactableMarkdownProcessor',
   output: {
     libraryTarget: 'umd',
   },


### PR DESCRIPTION
The original name was misleading; in remark, "parser" is the thing that reads text to an abstract syntax tree, "compiler" is the thing that generates text from an abstract syntax tree, and "processor" is the thing that unites the whole pipeline. The thing we were calling RedactableMarkdownParser is actually a processor.