### PR TITLE
 add an optional flag to redaction and restoration scripts for parsing content as plain text (rather than markdown)

### DIFF
--- a/src/bin/redact.js
+++ b/src/bin/redact.js
@@ -3,9 +3,11 @@
 const parseArgs = require('minimist');
 
 const ioUtils = require('../utils/io');
-const processor = require('../redactableMarkdownProcessor').create();
 const recursivelyProcessAll = require('../utils/misc').recursivelyProcessAll;
 const requireByPath = require('../utils/misc').requireByPath;
+
+const MarkdownProcessor = require('../redactableMarkdownProcessor');
+const TextProcessor = require('../redactableProcessor');
 
 const argv = parseArgs(process.argv.slice(2));
 
@@ -20,9 +22,18 @@ if (helpFlag) {
   process.stdout.write("options:\n");
   process.stdout.write("\t-h, --help: print this help message\n");
   process.stdout.write("\t-o OUTFILE: output to OUTFILE rather than stdout\n");
+  process.stdout.write("\t-f, --format [md|txt]: specify format of content (default to markdown)\n");
   process.stdout.write("\t-p, --parserPlugins PLUGINS: comma-separated list of parser plugins to include in addition to the defaults\n");
   process.stdout.write("\t-c, --compilerPlugins PLUGINS: comma-separated list of compiler plugins to include in addition to the defaults\n");
   process.exit()
+}
+
+const format = (argv.f || argv.format)
+let processor;
+if (format && format === 'txt') {
+  processor = TextProcessor.create()
+} else {
+  processor = MarkdownProcessor.create()
 }
 
 const parserPlugins = (argv.p || argv.parserPlugins)

--- a/src/bin/restore.js
+++ b/src/bin/restore.js
@@ -3,9 +3,11 @@
 const parseArgs = require('minimist');
 
 const ioUtils = require('../utils/io');
-const processor = require('../redactableMarkdownProcessor').create();
 const recursivelyProcessAll = require('../utils/misc').recursivelyProcessAll;
 const requireByPath = require('../utils/misc').requireByPath;
+
+const MarkdownProcessor = require('../redactableMarkdownProcessor');
+const TextProcessor = require('../redactableProcessor');
 
 const argv = parseArgs(process.argv.slice(2));
 
@@ -16,9 +18,18 @@ if (helpFlag || missingRequiredFlags) {
   process.stdout.write("options:\n");
   process.stdout.write("\t-h, --help: print this help message\n");
   process.stdout.write("\t-o OUTFILE: output to OUTFILE rather than stdout\n");
+  process.stdout.write("\t-f, --format [md|txt]: specify format of content (default to markdown)\n");
   process.stdout.write("\t-p, --parserPlugins PLUGINS: comma-separated list of parser plugins to include in addition to the defaults\n");
   process.stdout.write("\t-c, --compilerPlugins PLUGINS: comma-separated list of compiler plugins to include in addition to the defaults\n");
   process.exit()
+}
+
+const format = (argv.f || argv.format)
+let processor;
+if (format && format === 'txt') {
+  processor = TextProcessor.create()
+} else {
+  processor = MarkdownProcessor.create()
 }
 
 const parserPlugins = (argv.p || argv.parserPlugins)

--- a/test/integration/data/plaintext/redacted.txt
+++ b/test/integration/data/plaintext/redacted.txt
@@ -1,0 +1,1 @@
+Some text with an_underscore that would normally get escaped

--- a/test/integration/data/plaintext/source.txt
+++ b/test/integration/data/plaintext/source.txt
@@ -1,0 +1,1 @@
+Some text with an_underscore that would normally get escaped


### PR DESCRIPTION
depends on https://github.com/code-dot-org/redactable-markdown/pull/60