### PR TITLE
upgrading packages and adding redaction transformation

### DIFF
--- a/.github/workflows/continuous-integration-tests.yml
+++ b/.github/workflows/continuous-integration-tests.yml
@@ -1,0 +1,25 @@
+name: Continuous Integration Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Infer node version from .nvmrc, courtesy of https://github.com/actions/setup-node/issues/32#issuecomment-539794249
+      - name: Read .nvmrc
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        id: nvm
+      - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # redactable-markdown
 
-[![Travis Build Status](https://img.shields.io/travis/code-dot-org/redactable-markdown/master.svg)](https://travis-ci.org/code-dot-org/redactable-markdown/)
+[![Build Status](https://github.com/code-dot-org/redactable-markdown/actions/workflows/continuous-integration-tests.yml/badge.svg?branch=master)](https://github.com/code-dot-org/redactable-markdown/actions/workflows/continuous-integration-tests.yml)
 [![npm version](https://img.shields.io/npm/v/@code-dot-org/redactable-markdown.svg)](https://www.npmjs.com/package/@code-dot-org/redactable-markdown)
 
 tools for parsing and translating the modified version of markdown used by code.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@code-dot-org/remark-plugins": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@code-dot-org/remark-plugins/-/remark-plugins-1.2.1.tgz",
-      "integrity": "sha512-W+pVnQAb4jBDQZLSnS/+hZ4ZW2RNDF6/uBj1z72RNi69hKMoEJdjX5zIKaUAyYt5Qbqo65tuY0yBq/Hy/Kdk8Q=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@code-dot-org/remark-plugins/-/remark-plugins-1.2.3.tgz",
+      "integrity": "sha512-sRrWlbQVHPyLpKiEH1Ux2moSnSjyB9i29INA8CXWEcOD1ARh75gakzt3Bchp7FuvoZuWTlKJXeboJePgDze0Dw=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -4364,7 +4364,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4385,12 +4386,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4405,17 +4408,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4532,7 +4538,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4544,6 +4551,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4558,6 +4566,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4565,12 +4574,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4589,6 +4600,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4669,7 +4681,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4681,6 +4694,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4766,7 +4780,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4802,6 +4817,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4821,6 +4837,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4864,12 +4881,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9453,9 +9472,9 @@
       }
     },
     "remark-redactable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/remark-redactable/-/remark-redactable-1.0.0.tgz",
-      "integrity": "sha512-mHBppexkNVXhgARghBLFklZPEUVjgxzM3TV3kclM6Cr4gPZ7UtwPF222OyUVHlikTV5xdb1yM6Tz+m3eEIfkiw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remark-redactable/-/remark-redactable-2.0.1.tgz",
+      "integrity": "sha512-DZgFJ17moEU3M9f9lhVdyxUT0RcuCw1Jx3rlv3TgyHwfy9DUDI8d9HrhlROzeSBvIhMz4lp53ecPHrT8oKyvsQ=="
     },
     "remark-stringify": {
       "version": "6.0.4",

--- a/package.json
+++ b/package.json
@@ -56,11 +56,11 @@
     "webpack-cli": "2.1.3"
   },
   "dependencies": {
-    "@code-dot-org/remark-plugins": "1.2.1",
+    "@code-dot-org/remark-plugins": "1.2.3",
     "minimist": "^1.2.0",
     "remark-html": "^9.0.0",
     "remark-parse": "^6.0.0",
-    "remark-redactable": "1.0.0",
+    "remark-redactable": "2.0.1",
     "remark-stringify": "^6.0.0",
     "unified": "^7.0.0",
     "unist-util-select": "^2.0.2",

--- a/src/redactableProcessor.js
+++ b/src/redactableProcessor.js
@@ -27,11 +27,15 @@ module.exports = class RedactableProcessor {
   }
 
   sourceToRedactedSyntaxTree(source) {
-    return unified()
+    const parsedRedactionTree = unified()
       .use(this.constructor.getParser())
       .use(redact)
       .use(this.parserPlugins)
       .parse(source);
+    return unified()
+      .use(this.constructor.getParser())
+      .use(redact)
+      .runSync(parsedRedactionTree);
   }
 
   redactedToSyntaxTree(redacted, strict) {


### PR DESCRIPTION
This PR upgrades the `remark-redactable` and `remark-plugins` versions, and adds a transformation step during redaction to be compatible with the new `remark-redactable` version.