### PR TITLE
Removed remark-html in favor of Rehype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@code-dot-org/redactable-markdown",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@code-dot-org/redactable-markdown",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@code-dot-org/remark-plugins": "1.2.4",
+        "@code-dot-org/remark-plugins": "2.0.0",
         "hast-util-sanitize": "^3.0.2",
         "minimist": "^1.2.8",
         "rehype-raw": "^5.1.0",
@@ -1864,9 +1864,9 @@
       "dev": true
     },
     "node_modules/@code-dot-org/remark-plugins": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@code-dot-org/remark-plugins/-/remark-plugins-1.2.4.tgz",
-      "integrity": "sha512-texE/vSeXiAW9Dki/Xthm6leeYuGegRfZnwgSDScLHCNoah3uLWo+tEz/pm1hIgFHwPJjGV0fWsA7Sau6gglfg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@code-dot-org/remark-plugins/-/remark-plugins-2.0.0.tgz",
+      "integrity": "sha512-EGIoUUCpZ0BumfPZhkrBtlffzyVcFCmB+8oRas4OC/fXe7EbIchSG8KeZK21igsBuru/so/FYkigb4eAv0gCwQ=="
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,17 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@code-dot-org/remark-plugins": "1.2.4",
+        "hast-util-sanitize": "^3.0.2",
         "minimist": "^1.2.8",
-        "remark-html": "^9.0.0",
-        "remark-parse": "^6.0.0",
+        "rehype-raw": "^5.1.0",
+        "rehype-sanitize": "^4.0.0",
+        "rehype-stringify": "^8.0.0",
+        "remark-parse": "^6.0.3",
         "remark-redactable": "2.0.2",
-        "remark-stringify": "^6.0.0",
-        "unified": "^7.0.0",
-        "unist-util-select": "^2.0.2",
+        "remark-rehype": "8.1.0",
+        "remark-stringify": "^8.1.1",
+        "unified": "^9.2.2",
+        "unist-util-select": "^3.0.4",
         "xtend": "^4.0.2"
       },
       "bin": {
@@ -2874,6 +2878,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -2910,10 +2922,24 @@
       "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
       "dev": true
     },
+    "node_modules/@types/mdast": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.7.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.0.tgz",
-      "integrity": "sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg=="
+      "integrity": "sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg==",
+      "dev": true
+    },
+    "node_modules/@types/parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
+      "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -2925,25 +2951,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
       "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
-    },
-    "node_modules/@types/vfile": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
-      "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/unist": "*",
-        "@types/vfile-message": "*"
-      }
-    },
-    "node_modules/@types/vfile-message": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-2.0.0.tgz",
-      "integrity": "sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==",
-      "deprecated": "This is a stub types definition. vfile-message provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "vfile-message": "*"
-      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.25",
@@ -4322,18 +4329,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/detab": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.4.tgz",
-      "integrity": "sha512-8zdsQA5bIkoRECvCrNKPla84lyoR7DSAyf7p0YgXzBO9PDJx8KntPUay7NS6yp+KdxdVtiE5SpHKtbp2ZQyA9g==",
-      "dependencies": {
-        "repeat-string": "^1.5.4"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -5388,6 +5383,41 @@
         "node": ">=4"
       }
     },
+    "node_modules/hast-to-hyperscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-9.0.1.tgz",
+      "integrity": "sha512-zQgLKqF+O2F72S1aa4y2ivxzSlko3MAvxkwG8ehGmNiqd98BIN3JM1rAJPmplEyLmGLO2QZYJtIneOSZ2YbJuA==",
+      "dependencies": {
+        "@types/unist": "^2.0.3",
+        "comma-separated-tokens": "^1.0.0",
+        "property-information": "^5.3.0",
+        "space-separated-tokens": "^1.0.0",
+        "style-to-object": "^0.3.0",
+        "unist-util-is": "^4.0.0",
+        "web-namespaces": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-6.0.1.tgz",
+      "integrity": "sha512-jeJUWiN5pSxW12Rh01smtVkZgZr33wBokLzKLwinYOUfSzm1Nl/c3GUGebDyOKjdsRgMvoVbV0VpAcpjF4NrJA==",
+      "dependencies": {
+        "@types/parse5": "^5.0.0",
+        "hastscript": "^6.0.0",
+        "property-information": "^5.0.0",
+        "vfile": "^4.0.0",
+        "vfile-location": "^3.2.0",
+        "web-namespaces": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz",
@@ -5397,35 +5427,85 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-sanitize": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz",
-      "integrity": "sha512-AIeKHuHx0Wk45nSkGVa2/ujQYTksnDl8gmmKo/mwQi7ag7IBZ8cM3nJ2G86SajbjGP/HRpud6kMkPtcM2i0Tlw==",
-      "dependencies": {
-        "xtend": "^4.0.1"
+    "node_modules/hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-to-html": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-5.0.1.tgz",
-      "integrity": "sha512-zPuZuclFMJAP50wi9FoP3fcjOWmP3A9CqiPiR1nqOoweYDB4Urc2tg4ZITeDOrOjUQG5zArGopeGDuu3+vkGQg==",
+    "node_modules/hast-util-raw": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-6.1.0.tgz",
+      "integrity": "sha512-5FoZLDHBpka20OlZZ4I/+RBw5piVQ8iI1doEvffQhx5CbCyTtP8UCq8Tw6NmTAMtXgsQxmhW7Ly8OdFre5/YMQ==",
       "dependencies": {
-        "ccount": "^1.0.0",
-        "comma-separated-tokens": "^1.0.1",
-        "hast-util-is-element": "^1.0.0",
-        "hast-util-whitespace": "^1.0.0",
+        "@types/hast": "^2.0.0",
+        "hast-util-from-parse5": "^6.0.0",
+        "hast-util-to-parse5": "^6.0.0",
         "html-void-elements": "^1.0.0",
+        "parse5": "^6.0.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^2.0.0",
+        "vfile": "^4.0.0",
+        "web-namespaces": "^1.0.0",
+        "xtend": "^4.0.0",
+        "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-3.0.2.tgz",
+      "integrity": "sha512-+2I0x2ZCAyiZOO/sb4yNLFmdwPBnyJ4PBkVTUMKMqBwYNA+lXSgOmoRXlJFazoyid9QPogRRKgKhVEodv181sA==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-6.0.0.tgz",
+      "integrity": "sha512-Lu5m6Lgm/fWuz8eWnrKezHtVY83JeRGaNQ2kn9aJgqaxvVkFCZQBEhgodZUDUvoodgyROHDb3r5IxAEdl6suJQ==",
+      "dependencies": {
+        "hast-to-hyperscript": "^9.0.0",
         "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unist-util-is": "^2.0.0",
-        "xtend": "^4.0.1"
+        "web-namespaces": "^1.0.0",
+        "xtend": "^4.0.0",
+        "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hast-util-whitespace": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
       "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+      "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -5604,6 +5684,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
+    },
     "node_modules/interpret": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
@@ -5768,11 +5853,11 @@
       }
     },
     "node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/is-plain-object": {
@@ -7796,50 +7881,27 @@
       }
     },
     "node_modules/markdown-table": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
-      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "dependencies": {
+        "repeat-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/mdast-util-compact": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.4.tgz",
-      "integrity": "sha512-3YDMQHI5vRiS2uygEFYaqckibpJtKq5Sj2c8JioeOQBU6INpKbdWzfyLqFFnDwEcEnRFIdMsguzs5pC1Jp4Isg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz",
+      "integrity": "sha512-7GlnT24gEwDrdAwEHrU4Vv5lLWrEer4KOkAiKT9nYstsTad7Oc1TwqT2zIMKRdZF7cTuaf+GA1E4Kv7jJh8mPA==",
       "dependencies": {
-        "unist-util-visit": "^1.1.0"
+        "unist-util-visit": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-definitions": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
-      "integrity": "sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==",
-      "dependencies": {
-        "unist-util-visit": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-hast": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-4.0.0.tgz",
-      "integrity": "sha512-yOTZSxR1aPvWRUxVeLaLZ1sCYrK87x2Wusp1bDM/Ao2jETBhYUKITI3nHvgy+HkZW54HuCAhHnS0mTcbECD5Ig==",
-      "dependencies": {
-        "collapse-white-space": "^1.0.0",
-        "detab": "^2.0.0",
-        "mdast-util-definitions": "^1.2.0",
-        "mdurl": "^1.0.1",
-        "trim": "0.0.1",
-        "trim-lines": "^1.0.0",
-        "unist-builder": "^1.0.1",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.0",
-        "xtend": "^4.0.1"
       }
     },
     "node_modules/mdurl": {
@@ -7986,7 +8048,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -7998,6 +8059,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8146,6 +8208,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "node_modules/pascal-case": {
       "version": "3.1.2",
@@ -8515,6 +8582,63 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/rehype-raw": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-5.1.0.tgz",
+      "integrity": "sha512-MDvHAb/5mUnif2R+0IPCYJU8WjHa9UzGtM/F4AVy5GixPlDZ1z3HacYy4xojDU+uBa+0X/3PIfyQI26/2ljJNA==",
+      "dependencies": {
+        "hast-util-raw": "^6.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-4.0.0.tgz",
+      "integrity": "sha512-ZCr/iQRr4JeqPjun5i9CHHILVY7i45VnLu1CkkibDrSyFQ7dTLSvw8OIQpHhS4RSh9h/9GidxFw1bRb0LOxIag==",
+      "dependencies": {
+        "hast-util-sanitize": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-8.0.0.tgz",
+      "integrity": "sha512-VkIs18G0pj2xklyllrPSvdShAV36Ff3yE5PUO9u36f6+2qJFnn22Z5gKwBOwgXviux4UC7K+/j13AnZfPICi/g==",
+      "dependencies": {
+        "hast-util-to-html": "^7.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify/node_modules/hast-util-to-html": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-7.1.3.tgz",
+      "integrity": "sha512-yk2+1p3EJTEE9ZEUkgHsUSVhIpCsL/bvT8E5GzmWc+N1Po5gBw+0F8bo7dpxXR0nu0bQVxVZGX2lBGF21CmeDw==",
+      "dependencies": {
+        "ccount": "^1.0.0",
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-is-element": "^1.0.0",
+        "hast-util-whitespace": "^1.0.0",
+        "html-void-elements": "^1.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0",
+        "stringify-entities": "^3.0.1",
+        "unist-util-is": "^4.0.0",
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -8522,17 +8646,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/remark-html": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-9.0.1.tgz",
-      "integrity": "sha512-1Kbk5nb3RCdVxWATOu+ZW66muXoe0NjVgIxFmCb5eOB9Vezgd7gqkOhkKjKks9Jgorwiv5l81av64UWAwuYD/Q==",
-      "dependencies": {
-        "hast-util-sanitize": "^1.0.0",
-        "hast-util-to-html": "^5.0.0",
-        "mdast-util-to-hast": "^4.0.0",
-        "xtend": "^4.0.1"
       }
     },
     "node_modules/remark-parse": {
@@ -8557,15 +8670,76 @@
         "xtend": "^4.0.1"
       }
     },
+    "node_modules/remark-parse/node_modules/vfile-location": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-redactable": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/remark-redactable/-/remark-redactable-2.0.2.tgz",
       "integrity": "sha512-EI6n4xpOx8plReuMu5s5XJBPYyj/hXyHhc5ps/8Ewd0OgLLstV/q/QhbwqXZEz6TUDcnUsEHqTU8KWq18OO7cA=="
     },
+    "node_modules/remark-rehype": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-8.1.0.tgz",
+      "integrity": "sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==",
+      "dependencies": {
+        "mdast-util-to-hast": "^10.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/mdast-util-definitions": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz",
+      "integrity": "sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==",
+      "dependencies": {
+        "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/mdast-util-to-hast": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz",
+      "integrity": "sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "mdast-util-definitions": "^4.0.0",
+        "mdurl": "^1.0.0",
+        "unist-builder": "^2.0.0",
+        "unist-util-generated": "^1.0.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/unist-builder": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
+      "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-stringify": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
-      "integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.1.tgz",
+      "integrity": "sha512-q4EyPZT3PcA3Eq7vPpT6bIdokXzFGp9i85igjmhRyXWmPs0Y6/d2FYwUNotKAWyLch7g0ASZJn/KHHcHZQ163A==",
       "dependencies": {
         "ccount": "^1.0.0",
         "is-alphanumeric": "^1.0.0",
@@ -8573,14 +8747,35 @@
         "is-whitespace-character": "^1.0.0",
         "longest-streak": "^2.0.1",
         "markdown-escapes": "^1.0.0",
-        "markdown-table": "^1.1.0",
-        "mdast-util-compact": "^1.0.0",
-        "parse-entities": "^1.0.2",
+        "markdown-table": "^2.0.0",
+        "mdast-util-compact": "^2.0.0",
+        "parse-entities": "^2.0.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
-        "stringify-entities": "^1.0.1",
+        "stringify-entities": "^3.0.0",
         "unherit": "^1.0.4",
         "xtend": "^4.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/renderkid": {
@@ -8602,14 +8797,6 @@
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/replace-ext": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-      "integrity": "sha512-vuNYXC7gG7IeVNBC1xUllqCcZKRbJoSPOBhnTEcAIiKCsbuef6zO3F0Rve3isPMMoNoQRWjQwbAgAjHUHniyEA==",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/require-directory": {
@@ -8981,14 +9168,17 @@
       }
     },
     "node_modules/stringify-entities": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
-      "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.1.0.tgz",
+      "integrity": "sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==",
       "dependencies": {
         "character-entities-html4": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -9031,6 +9221,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+      "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
       }
     },
     "node_modules/supports-color": {
@@ -9259,15 +9457,6 @@
       "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==",
       "deprecated": "Use String.prototype.trim() instead"
     },
-    "node_modules/trim-lines": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.3.tgz",
-      "integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/trim-trailing-lines": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
@@ -9379,26 +9568,20 @@
       }
     },
     "node_modules/unified": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
-      "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+      "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
       "dependencies": {
-        "@types/unist": "^2.0.0",
-        "@types/vfile": "^3.0.0",
         "bail": "^1.0.0",
         "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^2.0.0",
         "trough": "^1.0.0",
-        "vfile": "^3.0.0",
-        "x-is-string": "^0.1.0"
-      }
-    },
-    "node_modules/unist-builder": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
-      "integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
-      "dependencies": {
-        "object-assign": "^4.1.0"
+        "vfile": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unist-util-generated": {
@@ -9411,9 +9594,13 @@
       }
     },
     "node_modules/unist-util-is": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-      "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/unist-util-position": {
       "version": "3.1.0",
@@ -9436,37 +9623,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-select": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-2.0.2.tgz",
-      "integrity": "sha512-Yv5Z5ShMxv7Z9Dw175tKvOiRVXV4FrMHG778DSD9Z0jALgb3wAx9DoeInr3200QlYp71rYUXzzJdCb76xKdrCw==",
-      "dependencies": {
-        "css-selector-parser": "^1.1.0",
-        "not": "^0.1.0",
-        "nth-check": "^1.0.1",
-        "unist-util-is": "^3.0.0",
-        "zwitch": "^1.0.3"
-      }
-    },
-    "node_modules/unist-util-select/node_modules/nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "dependencies": {
-        "boolbase": "~1.0.0"
-      }
-    },
-    "node_modules/unist-util-select/node_modules/unist-util-is": {
+    "node_modules/unist-util-remove-position/node_modules/unist-util-is": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
       "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
     },
-    "node_modules/unist-util-stringify-position": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
-    },
-    "node_modules/unist-util-visit": {
+    "node_modules/unist-util-remove-position/node_modules/unist-util-visit": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
       "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
@@ -9474,7 +9636,7 @@
         "unist-util-visit-parents": "^2.0.0"
       }
     },
-    "node_modules/unist-util-visit-parents": {
+    "node_modules/unist-util-remove-position/node_modules/unist-util-visit-parents": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
       "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
@@ -9482,10 +9644,60 @@
         "unist-util-is": "^3.0.0"
       }
     },
-    "node_modules/unist-util-visit-parents/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+    "node_modules/unist-util-select": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-3.0.4.tgz",
+      "integrity": "sha512-xf1zCu4okgPqGLdhCDpRnjwBNyv3EqjiXRUbz2SdK1+qnLMB7uXXajfzuBvvbHoQ+JLyp4AEbFCGndmc6S72sw==",
+      "dependencies": {
+        "css-selector-parser": "^1.0.0",
+        "not": "^0.1.0",
+        "nth-check": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dependencies": {
+        "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -9553,61 +9765,40 @@
       "dev": true
     },
     "node_modules/vfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
-      "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
       "dependencies": {
+        "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
-        "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vfile-location": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz",
+      "integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vfile-message": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
-      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
       "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-stringify-position": "^4.0.0"
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message/node_modules/@types/unist": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
-      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
-    },
-    "node_modules/vfile-message/node_modules/unist-util-stringify-position": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile/node_modules/vfile-message": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
-      "dependencies": {
-        "unist-util-stringify-position": "^1.1.1"
       }
     },
     "node_modules/walker": {
@@ -9630,6 +9821,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
+      "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/webpack": {
@@ -9871,11 +10071,6 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
-    },
-    "node_modules/x-is-string": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-      "integrity": "sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w=="
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/redactable-markdown",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "",
   "main": "dist/main.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    "@code-dot-org/remark-plugins": "1.2.4",
+    "@code-dot-org/remark-plugins": "2.0.0",
     "hast-util-sanitize": "^3.0.2",
     "minimist": "^1.2.8",
     "rehype-raw": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -55,16 +55,13 @@
     "@code-dot-org/remark-plugins": "1.2.4",
     "hast-util-sanitize": "^3.0.2",
     "minimist": "^1.2.8",
-
     "rehype-raw": "^5.1.0",
     "rehype-sanitize": "^4.0.0",
     "rehype-stringify": "^8.0.0",
-
     "remark-parse": "^6.0.3",
     "remark-redactable": "2.0.2",
     "remark-rehype": "8.1.0",
     "remark-stringify": "^8.1.1",
-
     "unified": "^9.2.2",
     "unist-util-select": "^3.0.4",
     "xtend": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
     "@babel/core": "^7.23.9",
-    "babel-loader": "^9.1.3",
-    "babel-plugin-transform-class-properties": "^6.24.1",
     "@babel/preset-env": "^7.23.9",
     "@babel/preset-react": "^7.23.3",
+    "babel-loader": "^9.1.3",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
@@ -53,13 +53,20 @@
   },
   "dependencies": {
     "@code-dot-org/remark-plugins": "1.2.4",
+    "hast-util-sanitize": "^3.0.2",
     "minimist": "^1.2.8",
-    "remark-html": "^9.0.0",
-    "remark-parse": "^6.0.0",
+
+    "rehype-raw": "^5.1.0",
+    "rehype-sanitize": "^4.0.0",
+    "rehype-stringify": "^8.0.0",
+
+    "remark-parse": "^6.0.3",
     "remark-redactable": "2.0.2",
-    "remark-stringify": "^6.0.0",
-    "unified": "^7.0.0",
-    "unist-util-select": "^2.0.2",
+    "remark-rehype": "8.1.0",
+    "remark-stringify": "^8.1.1",
+
+    "unified": "^9.2.2",
+    "unist-util-select": "^3.0.4",
     "xtend": "^4.0.2"
   },
   "jest": {

--- a/src/redactableMarkdownProcessor.js
+++ b/src/redactableMarkdownProcessor.js
@@ -1,5 +1,4 @@
 const unified = require("unified");
-// const html = require("remark-html");
 const remarkRehype = require("remark-rehype");
 const rehypeRaw = require("rehype-raw");
 const rehypeSanitize = require("rehype-sanitize");

--- a/src/redactableMarkdownProcessor.js
+++ b/src/redactableMarkdownProcessor.js
@@ -3,8 +3,8 @@ const remarkRehype = require("remark-rehype");
 const rehypeRaw = require("rehype-raw");
 const rehypeSanitize = require("rehype-sanitize");
 const rehypeStringify = require("rehype-stringify");
-const parse = require("remark-parse");
-const stringify = require("remark-stringify");
+const remarkParse = require("remark-parse");
+const remarkStringify = require("remark-stringify");
 const plugins = require("@code-dot-org/remark-plugins");
 const defaultSanitizationSchema = require("hast-util-sanitize/lib/github");
 
@@ -79,7 +79,7 @@ module.exports = class RedactableMarkdownProcessor extends RedactableProcessor {
    */
   static getParser() {
     return {
-      plugins: [parse],
+      plugins: [remarkParse],
       settings: {
         commonmark: true,
         pedantic: true,
@@ -91,7 +91,7 @@ module.exports = class RedactableMarkdownProcessor extends RedactableProcessor {
    * @override
    */
   static getCompiler() {
-    return stringify;
+    return remarkStringify;
   }
 
   /**

--- a/src/redactableMarkdownProcessor.js
+++ b/src/redactableMarkdownProcessor.js
@@ -1,10 +1,51 @@
 const unified = require("unified");
-const html = require("remark-html");
+// const html = require("remark-html");
+const remarkRehype = require("remark-rehype");
+const rehypeRaw = require("rehype-raw");
+const rehypeSanitize = require("rehype-sanitize");
+const rehypeStringify = require("rehype-stringify");
 const parse = require("remark-parse");
 const stringify = require("remark-stringify");
 const plugins = require("@code-dot-org/remark-plugins");
+const defaultSanitizationSchema = require("hast-util-sanitize/lib/github");
 
 const RedactableProcessor = require("./redactableProcessor");
+
+// create custom sanitization schema as per
+// https://github.com/syntax-tree/hast-util-sanitize#schema
+// to support our custom syntaxes
+const schema = Object.assign({}, defaultSanitizationSchema);
+schema.clobber = [];
+
+// We use a _lot_ of image formatting stuff in our
+// instructions, particularly in CSP
+schema.attributes.img.push("height", "width");
+
+// Add support for expandableImages
+schema.tagNames.push("span");
+schema.attributes.span = ["dataUrl", "className"];
+
+// Add support for inline styles (gross)
+// TODO replace all inline styles in our curriculum content with
+// semantically-significant content
+schema.attributes["*"].push("style", "className");
+
+// ClickableText uses data-id on a bold tag.
+schema.attributes["b"] = ["dataId"];
+
+// Add support for Blockly XML
+const blocklyTags = [
+  "block",
+  "functional_input",
+  "mutation",
+  "next",
+  "statement",
+  "title",
+  "field",
+  "value",
+  "xml",
+];
+schema.tagNames = schema.tagNames.concat(blocklyTags);
 
 module.exports = class RedactableMarkdownProcessor extends RedactableProcessor {
   constructor() {
@@ -16,7 +57,10 @@ module.exports = class RedactableMarkdownProcessor extends RedactableProcessor {
   sourceToHtml(source) {
     return unified()
       .use(this.constructor.getParser())
-      .use(html)
+      .use(remarkRehype, { allowDangerousHTML: true })
+      .use(rehypeRaw)
+      .use(rehypeSanitize, schema)
+      .use(rehypeStringify)
       .use(this.parserPlugins)
       .use(this.compilerPlugins)
       .processSync(source).contents;

--- a/src/redactableMarkdownProcessor.js
+++ b/src/redactableMarkdownProcessor.js
@@ -1,13 +1,13 @@
-const unified = require("unified");
-const remarkRehype = require("remark-rehype");
+const plugins = require("@code-dot-org/remark-plugins");
 const rehypeRaw = require("rehype-raw");
 const rehypeSanitize = require("rehype-sanitize");
 const rehypeStringify = require("rehype-stringify");
 const remarkParse = require("remark-parse");
+const remarkRehype = require("remark-rehype");
 const remarkStringify = require("remark-stringify");
-const plugins = require("@code-dot-org/remark-plugins");
-const defaultSanitizationSchema = require("hast-util-sanitize/lib/github");
+const unified = require("unified");
 
+const defaultSanitizationSchema = require("hast-util-sanitize/lib/github");
 const RedactableProcessor = require("./redactableProcessor");
 
 // create custom sanitization schema as per

--- a/test/integration/scripts.test.js
+++ b/test/integration/scripts.test.js
@@ -115,8 +115,6 @@ describe("Command-Line Scripts", () => {
             if (extension === extensions.text) {
               expectedContent = expectedContent.trim();
             }
-            console.log("DEBUGGING Expected", expectedContent);
-            console.log("DEBUGGING Returned", restore.stdout.toString());
             expect(restore.stdout.toString()).toEqual(expectedContent);
           });
         });

--- a/test/integration/scripts.test.js
+++ b/test/integration/scripts.test.js
@@ -115,6 +115,8 @@ describe("Command-Line Scripts", () => {
             if (extension === extensions.text) {
               expectedContent = expectedContent.trim();
             }
+            console.log("DEBUGGING Expected", expectedContent);
+            console.log("DEBUGGING Returned", restore.stdout.toString());
             expect(restore.stdout.toString()).toEqual(expectedContent);
           });
         });

--- a/test/unit/plugins/parser/paragraph.test.js
+++ b/test/unit/plugins/parser/paragraph.test.js
@@ -9,7 +9,7 @@ describe("paragraph", () => {
         const input = `First Paragraph\n${" ".repeat(i)}\nSecondParagraph`;
         const output = processor.sourceToHtml(input);
         expect(output).toEqual(
-          "<p>First Paragraph</p>\n<p>SecondParagraph</p>\n",
+          "<p>First Paragraph</p>\n<p>SecondParagraph</p>",
         );
       }
     });
@@ -18,7 +18,7 @@ describe("paragraph", () => {
         const input = `First Paragraph\n${" ".repeat(i)}\nSecondParagraph`;
         const output = processor.sourceToHtml(input);
         expect(output).toEqual(
-          "<p>First Paragraph</p>\n<p>SecondParagraph</p>\n",
+          "<p>First Paragraph</p>\n<p>SecondParagraph</p>",
         );
       }
     });

--- a/test/unit/plugins/parser/resourceLink.test.js
+++ b/test/unit/plugins/parser/resourceLink.test.js
@@ -11,7 +11,7 @@ describe("resourceLink", () => {
     it("cannot render resourceLinks to html", () => {
       const input = "[r some-slug/course-offering/1999]";
       const output = processor.sourceToHtml(input);
-      expect(output).toEqual("<p>[r some-slug/course-offering/1999]</p>\n");
+      expect(output).toEqual("<p>[r some-slug/course-offering/1999]</p>");
     });
   });
 
@@ -37,7 +37,7 @@ describe("resourceLink", () => {
       const source = "[r some-slug/course-offering/1999]";
       const redacted = "[any-text][0]";
       const output = processor.sourceAndRedactedToHtml(source, redacted);
-      expect(output).toEqual("<p>[r some-slug/course-offering/1999]</p>\n");
+      expect(output).toEqual("<p>[r some-slug/course-offering/1999]</p>");
     });
   });
 });

--- a/test/unit/plugins/parser/vocabularyDefinition.test.js
+++ b/test/unit/plugins/parser/vocabularyDefinition.test.js
@@ -11,7 +11,7 @@ describe("vocabularyDefinition", () => {
     it("can only render vocabularyDefinitions back out to plain text", () => {
       const input = "[v some_word/course-offering/1999]";
       const output = processor.sourceToHtml(input);
-      expect(output).toEqual("<p>[v some_word/course-offering/1999]</p>\n");
+      expect(output).toEqual("<p>[v some_word/course-offering/1999]</p>");
     });
   });
 

--- a/test/unit/redactableMarkdownProcessor.test.js
+++ b/test/unit/redactableMarkdownProcessor.test.js
@@ -7,7 +7,7 @@ describe("Standard Markdown", () => {
       const input = "This is some text with [a link](http://example.com)";
       const output = processor.sourceToHtml(input);
       expect(output).toEqual(
-        '<p>This is some text with <a href="http://example.com">a link</a></p>\n',
+        '<p>This is some text with <a href="http://example.com">a link</a></p>',
       );
     });
 
@@ -16,7 +16,7 @@ describe("Standard Markdown", () => {
         "This is some text that automatically links to <http://example.com>";
       const output = processor.sourceToHtml(input);
       expect(output).toEqual(
-        '<p>This is some text that automatically links to <a href="http://example.com">http://example.com</a></p>\n',
+        '<p>This is some text that automatically links to <a href="http://example.com">http://example.com</a></p>',
       );
     });
 
@@ -25,7 +25,7 @@ describe("Standard Markdown", () => {
         "- List item one.\n\n\t- Sublist item one\n\n\t- Sublist item two\n\n- List item two";
       const output = processor.sourceToHtml(input);
       expect(output).toEqual(
-        "<ul>\n<li>\n<p>List item one.</p>\n<ul>\n<li>\n<p>Sublist item one</p>\n</li>\n<li>\n<p>Sublist item two</p>\n</li>\n</ul>\n</li>\n<li>\n<p>List item two</p>\n</li>\n</ul>\n",
+        "<ul>\n<li>\n<p>List item one.</p>\n<ul>\n<li>\n<p>Sublist item one</p>\n</li>\n<li>\n<p>Sublist item two</p>\n</li>\n</ul>\n</li>\n<li>\n<p>List item two</p>\n</li>\n</ul>",
       );
     });
 
@@ -34,7 +34,7 @@ describe("Standard Markdown", () => {
         "1.  List item one.\n\n    List item one continued with a second paragraph followed by an\n    Indented block.\n\n        $ ls *.sh\n        $ mv *.sh ~/tmp\n\n    List item continued with a third paragraph.\n\n2.  List item two continued with an open block.\n\n    This paragraph is part of the preceding list item.\n\n    1. This list is nested and does not require explicit item continuation.\n\n       This paragraph is part of the preceding list item.\n\n    2. List item b.\n\n    This paragraph belongs to item two of the outer list.";
       const output = processor.sourceToHtml(input);
       expect(output).toEqual(
-        "<ol>\n<li>\n<p>List item one.</p>\n<p>List item one continued with a second paragraph followed by an\nIndented block.</p>\n<pre><code>$ ls *.sh\n$ mv *.sh ~/tmp\n</code></pre>\n<p>List item continued with a third paragraph.</p>\n</li>\n<li>\n<p>List item two continued with an open block.</p>\n<p>This paragraph is part of the preceding list item.</p>\n<ol>\n<li>\n<p>This list is nested and does not require explicit item continuation.</p>\n<p>This paragraph is part of the preceding list item.</p>\n</li>\n<li>\n<p>List item b.</p>\n</li>\n</ol>\n<p>This paragraph belongs to item two of the outer list.</p>\n</li>\n</ol>\n",
+        "<ol>\n<li>\n<p>List item one.</p>\n<p>List item one continued with a second paragraph followed by an\nIndented block.</p>\n<pre><code>$ ls *.sh\n$ mv *.sh ~/tmp\n</code></pre>\n<p>List item continued with a third paragraph.</p>\n</li>\n<li>\n<p>List item two continued with an open block.</p>\n<p>This paragraph is part of the preceding list item.</p>\n<ol>\n<li>\n<p>This list is nested and does not require explicit item continuation.</p>\n<p>This paragraph is part of the preceding list item.</p>\n</li>\n<li>\n<p>List item b.</p>\n</li>\n</ol>\n<p>This paragraph belongs to item two of the outer list.</p>\n</li>\n</ol>",
       );
     });
   });
@@ -99,7 +99,7 @@ describe("Standard Markdown", () => {
       const redacted = "Ceci est un texte avec [un lien][0]";
       const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual(
-        '<p>Ceci est un texte avec <a href="http://example.com/">un lien</a></p>\n',
+        '<p>Ceci est un texte avec <a href="http://example.com/">un lien</a></p>',
       );
     });
 
@@ -109,7 +109,7 @@ describe("Standard Markdown", () => {
       const redacted = "Ceci est un texte avec [une image][0]";
       const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual(
-        '<p>Ceci est un texte avec <img src="http://example.com/img.jpg" alt="une image"></p>\n',
+        '<p>Ceci est un texte avec <img src="http://example.com/img.jpg" alt="une image"></p>',
       );
     });
 
@@ -120,7 +120,7 @@ describe("Standard Markdown", () => {
         "C'est du texte avec [un lien][0] et [une image][1].\n\nEt aussi un deuxième paragraphe avec [un autre lien][2]";
       const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual(
-        '<p>C\'est du texte avec <a href="http://first.com">un lien</a> et <img src="http://second.com/img.jpg" alt="une image">.</p>\n<p>Et aussi un deuxième paragraphe avec <a href="http://third.com">un autre lien</a></p>\n',
+        '<p>C\'est du texte avec <a href="http://first.com">un lien</a> et <img src="http://second.com/img.jpg" alt="une image">.</p>\n<p>Et aussi un deuxième paragraphe avec <a href="http://third.com">un autre lien</a></p>',
       );
     });
 
@@ -129,7 +129,7 @@ describe("Standard Markdown", () => {
       const redacted = "Le [chat][1] [noir][0].";
       const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual(
-        '<p>Le <a href="http://second.com">chat</a> <a href="http://first.com">noir</a>.</p>\n',
+        '<p>Le <a href="http://second.com">chat</a> <a href="http://first.com">noir</a>.</p>',
       );
     });
 
@@ -140,7 +140,7 @@ describe("Standard Markdown", () => {
         "C'est du texte avec [un lien][0] et pas d'une image.\n\nEt aussi un deuxième paragraphe avec [un autre lien][2]";
       const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual(
-        '<p>C\'est du texte avec <a href="http://first.com">un lien</a> et pas d\'une image.</p>\n<p>Et aussi un deuxième paragraphe avec <a href="http://third.com">un autre lien</a></p>\n',
+        '<p>C\'est du texte avec <a href="http://first.com">un lien</a> et pas d\'une image.</p>\n<p>Et aussi un deuxième paragraphe avec <a href="http://third.com">un autre lien</a></p>',
       );
     });
 
@@ -149,7 +149,7 @@ describe("Standard Markdown", () => {
       const redacted = "C'est du texte avec [un lien][0] et [une image][1]";
       const output = processor.sourceAndRedactedToHtml(source, redacted);
       expect(output).toEqual(
-        '<p>C\'est du texte avec <a href="http://example.com/">un lien</a> et [une image][1]</p>\n',
+        '<p>C\'est du texte avec <a href="http://example.com/">un lien</a> et [une image][1]</p>',
       );
     });
 
@@ -159,7 +159,7 @@ describe("Standard Markdown", () => {
       const output = processor.sourceAndRedactedToHtml(source, redacted, true);
       // It would be nice if this didn't add a newline but it will be removed later
       // in the pipeline.
-      expect(output).toEqual("\n");
+      expect(output).toEqual("");
     });
 
     it("will handle removed redactions by rejecting them with flag set", () => {
@@ -168,7 +168,7 @@ describe("Standard Markdown", () => {
       const output = processor.sourceAndRedactedToHtml(source, redacted, true);
       // It would be nice if this didn't add a newline but it will be removed later
       // in the pipeline.
-      expect(output).toEqual("\n");
+      expect(output).toEqual("");
     });
   });
 });


### PR DESCRIPTION
## Story
DependaBot marked a few dependencies in this repo as high or critical. In addition, we are updating with similar changes, the [remark-plugins repo](https://github.com/code-dot-org/remark-plugins/pull/51).

## This PR does:

- Upgrades dependencies: [`remark-parse`](https://www.npmjs.com/package/remark-parse/v/6.0.3), [`unified`](https://www.npmjs.com/package/unified/v/9.2.2), [`unist-util-select`](https://www.npmjs.com/package/unist-util-select/v/3.0.4), [`remark-stringify`](https://www.npmjs.com/package/remark-stringify/v/8.1.1).
- Removes dependencies: [`remark-html`](https://www.npmjs.com/package/remark-html/v/13.0.1)
- Adds the following dependencies: [`rehype-raw`](https://www.npmjs.com/package/rehype-raw/v/5.1.0), [`rehype-sanitize`](https://www.npmjs.com/package/rehype-sanitize), [`rehype-stringify`](https://www.npmjs.com/package/rehype-stringify/v/8.0.0) and [`remark-rehype`](https://www.npmjs.com/package/remark-rehype/v/8.1.0). (Note that more recent versions of the unified ecosystem are only ESM compatible)
- Renames imported libraries to match the naming pattern used in our [main repo](https://github.com/code-dot-org/code-dot-org/blob/8d908ab6f9cf5c2ce413958f32e3c27d5ac095e/apps/src/templates/SafeMarkdown.jsx#L14-L17).
- Refactores the class `RedactableMarkdownProcessor` using rehype libraries instead of remark-html as we do in our [main repo](https://github.com/code-dot-org/code-dot-org/blob/8d2908ab6f9cf5c2ce413958f32e3c27d5ac095e/apps/src/templates/SafeMarkdown.jsx#L115-L140).
- Updates tests removing a `\n` introduced by `remak-html` (We no longer use remark-html)

After the update only two high-severity dependencies are left:
```
# npm audit report

trim  <0.0.3
Severity: high
Regular Expression Denial of Service in trim - https://github.com/advisories/GHSA-w5p7-h5w8-2hfq
fix available via `npm audit fix --force`
Will install remark-parse@11.0.0, which is a breaking change
node_modules/trim
  remark-parse  <=8.0.3
  Depends on vulnerable versions of trim
  node_modules/remark-parse

2 high severity vulnerabilities
```

However we don't use this library on our server side, therefore this vulnerability can't be exploited.
